### PR TITLE
feat: add heading and paragraph component

### DIFF
--- a/apps/ui/src/components/page-builder/components/Hero.tsx
+++ b/apps/ui/src/components/page-builder/components/Hero.tsx
@@ -2,6 +2,8 @@ import { Attribute } from "@repo/strapi"
 
 import { removeThisWhenYouNeedMe } from "@/lib/general-helpers"
 import { Container } from "@/components/elementary/Container"
+import Heading from "@/components/typography/Heading"
+import { Paragraph } from "@/components/typography/Paragraph"
 
 import { BasicImage } from "./BasicImage"
 import { LinkStrapi } from "./LinkStrapi"
@@ -19,13 +21,17 @@ export function Hero({
     <section style={{ backgroundColor: component.bgColor ?? "transparent" }}>
       <Container className="grid gap-8 px-4 py-8 md:grid-cols-12 lg:py-16 xl:gap-0">
         <div className="mr-auto flex w-full flex-col items-center justify-center md:col-span-7">
-          <h1 className="mb-4 max-w-2xl text-center text-4xl font-extrabold leading-none tracking-tight md:text-5xl xl:text-6xl">
+          <Heading
+            tag="h1"
+            variant="heading1"
+            className="mb-4 max-w-2xl text-center"
+          >
             {component.title}
-          </h1>
+          </Heading>
           {component.subTitle && (
-            <p className="mb-6 max-w-2xl font-light text-gray-500 md:text-lg lg:mb-8 lg:text-xl">
+            <Paragraph className="mb-6 max-w-2xl font-light text-gray-500">
               {component.subTitle}
-            </p>
+            </Paragraph>
           )}
 
           {component.links && (

--- a/apps/ui/src/components/typography/Heading.tsx
+++ b/apps/ui/src/components/typography/Heading.tsx
@@ -1,0 +1,51 @@
+import React from "react"
+
+import { cn } from "@/lib/styles"
+
+const variantStyles = {
+  heading3: "md:text-4xl text-2xl font-bold",
+  // more variants will be added here
+}
+
+const textColorVariants = {
+  black: "text-black",
+  white: "text-white",
+  // more variants will be added here
+}
+
+type Variant = keyof typeof variantStyles
+type TextColor = keyof typeof textColorVariants
+type HeadingTag = "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+
+interface HeadingProps {
+  children: React.ReactNode
+  className?: string
+  variant?: Variant
+  textColor?: TextColor
+  tag?: HeadingTag
+}
+
+const Heading = ({
+  children,
+  className,
+  variant = "heading3",
+  textColor = "black",
+  tag = "h3",
+}: HeadingProps) => {
+  const selectedVariant = variantStyles[variant]
+  const selectedTextColor = textColorVariants[textColor]
+
+  const Tag = tag as HeadingTag
+
+  if (!Tag) {
+    return null
+  }
+
+  return (
+    <Tag className={cn(selectedVariant, selectedTextColor, className)}>
+      {children}
+    </Tag>
+  )
+}
+
+export default Heading

--- a/apps/ui/src/components/typography/Heading.tsx
+++ b/apps/ui/src/components/typography/Heading.tsx
@@ -3,6 +3,8 @@ import React from "react"
 import { cn } from "@/lib/styles"
 
 const variantStyles = {
+  heading1:
+    "text-4xl font-extrabold leading-none tracking-tight md:text-5xl xl:text-6xl",
   heading3: "md:text-4xl text-2xl font-bold",
   // more variants will be added here
 }

--- a/apps/ui/src/components/typography/Paragraph.tsx
+++ b/apps/ui/src/components/typography/Paragraph.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+
+import { cn } from "@/lib/styles"
+
+export const variantStyles = {
+  base: "text-base leading-[25px]",
+  // more variants will be added here
+}
+
+export const textColorVariants = {
+  black: "text-black",
+  white: "text-white",
+  // more variants will be added here
+}
+
+type Variant = keyof typeof variantStyles
+type TextColor = keyof typeof textColorVariants
+
+export const Paragraph = ({
+  children,
+  className,
+  variant = "base",
+  textColor = "black",
+}: {
+  className?: string
+  children?: React.ReactNode
+  variant?: Variant
+  textColor?: TextColor
+}) => {
+  const selectedVariant = variantStyles[variant]
+  const selectedTextColor = textColorVariants[textColor]
+
+  return (
+    <p className={cn(selectedVariant, selectedTextColor, className)}>
+      {children}
+    </p>
+  )
+}


### PR DESCRIPTION
## Description

- closes [#13 ](https://github.com/notum-cz/strapi-next-monorepo-starter/issues/13)
- this PR adds Paragraph and Heading component to define a basic typography in a project