### PR TITLE
chore: upgrade node to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
-    
+
       - name: Cache turbo build setup
         uses: actions/cache@v4
         with:
@@ -24,16 +24,16 @@ jobs:
           key: '${{ runner.os }}-turbo-${{ github.sha }}'
           restore-keys: |
             ${{ runner.os }}-turbo-
-      
+
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
-      
+
       - name: Install dependencies
         run: yarn
-      
+
       - name: Build UI
         run: yarn build:ui
         env:
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build Strapi
         run: yarn build:strapi
-        
+
 
 
 

--- a/apps/strapi/Dockerfile
+++ b/apps/strapi/Dockerfile
@@ -1,4 +1,4 @@
-# This is PRODUCTION Dockerfile for Strapi in Turborepo. 
+# This is PRODUCTION Dockerfile for Strapi in Turborepo.
 # It's assumed that this Dockerfile is run from the root of the monorepo.
 
 # Created according to following examples:
@@ -10,7 +10,7 @@
 ARG APP=strapi
 ARG WORKSPACE=@repo/strapi
 
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk update && apk add --no-cache libc6-compat
 
@@ -49,10 +49,10 @@ RUN \
     --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
     yarn --prefer-offline --frozen-lockfile --ignore-scripts --production
 
-# Because of yarn v1 install sharp explicitly with "--ignore-engines". See https://github.com/lovell/sharp/issues/3871    
+# Because of yarn v1 install sharp explicitly with "--ignore-engines". See https://github.com/lovell/sharp/issues/3871
 RUN \
     --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
-    yarn workspace ${WORKSPACE} add sharp --ignore-engines --prefer-offline --frozen-lockfile 
+    yarn workspace ${WORKSPACE} add sharp --ignore-engines --prefer-offline --frozen-lockfile
 
 ENV PATH /app/apps/${APP}/node_modules/.bin:$PATH
 

--- a/apps/strapi/package.json
+++ b/apps/strapi/package.json
@@ -46,7 +46,7 @@
     "react-router-dom": "^6.0.0",
     "slugify": "^1.6.6",
     "strapi-plugin-config-sync": "2",
-    "strapi-v5-plugin-populate-deep": "^4.0.4",
+    "strapi-v5-plugin-populate-deep": "^4.0.5",
     "styled-components": "^6.0.0"
   },
   "devDependencies": {

--- a/apps/strapi/package.json
+++ b/apps/strapi/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5"
   },
   "engines": {
-    "node": "20.x.x",
+    "node": "22.x.x",
     "yarn": "1.22.x"
   },
   "strapi": {

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -1,4 +1,4 @@
-# This is PRODUCTION Dockerfile for NextJS in Turborepo. 
+# This is PRODUCTION Dockerfile for NextJS in Turborepo.
 # It's assumed that this Dockerfile is run from the root of the monorepo.
 
 # Created according to following examples:
@@ -9,7 +9,7 @@
 ARG APP=ui
 ARG WORKSPACE=@repo/ui
 
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk update && apk add --no-cache libc6-compat
 
@@ -43,10 +43,10 @@ RUN \
     --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
     yarn --prefer-offline --frozen-lockfile --ignore-scripts
 
-# Because of yarn v1 install sharp explicitly with "--ignore-engines". See https://github.com/lovell/sharp/issues/3871    
+# Because of yarn v1 install sharp explicitly with "--ignore-engines". See https://github.com/lovell/sharp/issues/3871
 RUN \
     --mount=type=cache,target=/usr/local/share/.cache/yarn/v6,sharing=locked \
-    yarn workspace ${WORKSPACE} add sharp --ignore-engines --prefer-offline --frozen-lockfile 
+    yarn workspace ${WORKSPACE} add sharp --ignore-engines --prefer-offline --frozen-lockfile
 
 # Build the project and its dependencies
 COPY --from=pruned /app/out/full/ .

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -82,7 +82,7 @@
     "typescript": "^5"
   },
   "engines": {
-    "node": "20.x.x",
+    "node": "22.x.x",
     "yarn": "1.22.x"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "yarn@1.22.22",
   "engines": {
-    "node": "20.x.x",
+    "node": "22.x.x",
     "yarn": "1.22.x"
   },
   "comments": {


### PR DESCRIPTION
- upgrades node references in "engines" to 22
- node:22-alpine used as base image in Dockerfiles