### PR TITLE
fix(i18n): include locale in the return object

### DIFF
--- a/apps/ui/src/lib/i18n.ts
+++ b/apps/ui/src/lib/i18n.ts
@@ -12,6 +12,7 @@ export default getRequestConfig(async ({ requestLocale }) => {
   }
 
   return {
+    locale,
     messages: (
       await (locale === "en"
         ? // When using Turbopack, this will enable HMR for `en`


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9ef803f6-8dca-47dc-9de7-214c31b03178)
