### PR TITLE
fix: structured data not updated on client navigation

### DIFF
--- a/apps/ui/src/components/page-builder/components/seo-utilities/StrapiStructuredData.tsx
+++ b/apps/ui/src/components/page-builder/components/seo-utilities/StrapiStructuredData.tsx
@@ -1,5 +1,3 @@
-import Script from "next/script"
-
 import type { Data } from "@repo/strapi"
 
 export const StrapiStructuredData = ({
@@ -8,16 +6,15 @@ export const StrapiStructuredData = ({
   structuredData: Data.Component<"seo-utilities.seo">["structuredData"]
 }) => {
   if (structuredData) {
+    // we need to use a plain `script` tag instead of the `Script` component
+    // `Script` component is optimized by Next, which works against us in this case
+    // - if id is specified, the content will not be updated on client navigation
+    // - if no id is specified, a new script tag will be added with the new content, which schema validators are not able to parse.
+    // `script` tag is properly re-rendered and replaced with the new content
     return (
-      <Script
-        id="articleStructuredData"
-        strategy="afterInteractive"
-        type="application/ld+json"
-        // this content is limited to Strapi and cannot be sourced from users
-        dangerouslySetInnerHTML={{
-          __html: JSON.stringify(structuredData),
-        }}
-      />
+      <script id="articleStructuredData" type="application/ld+json">
+        {JSON.stringify(structuredData)}
+      </script>
     )
   }
 


### PR DESCRIPTION
replaces `<Script>` next component with plain old `<script>` html tag for structured data

Script components are optimized to be included exactly once, if they have an id.
If they don't have an id, new script tag is added, which schema validator and structured data extensions are not able to work with. (Same goes most likely for crawlers, but this is only an assumption).

This means only structured data for the first load is included and any subsequent client navigation does not update it.

Using <script> tag results in structured data being correctly replaced.

Impact of the bug is most likely minimal (crawlers do get the correct data on first load and if they don't perform any further navigation, they do not encounter it).