### PR TITLE
fix(proxy): fetch api not working with form data

### DIFF
--- a/apps/ui/src/app/api/private-proxy/[...slug]/route.ts
+++ b/apps/ui/src/app/api/private-proxy/[...slug]/route.ts
@@ -24,7 +24,17 @@ async function handler(
 
   const clonedRequest = request.clone()
   // Extract the body explicitly from the cloned request
-  const body = isReadOnly ? undefined : await clonedRequest.text()
+  let body: string | Blob | undefined
+  if (!isReadOnly) {
+    const contentType = clonedRequest.headers.get("content-type")
+    if (contentType?.includes("multipart/form-data")) {
+      // File upload - preserve FormData as blob
+      body = await clonedRequest.blob()
+    } else {
+      // Regular API call - use text for JSON
+      body = await clonedRequest.text()
+    }
+  }
 
   const response = await fetch(url, {
     headers: {

--- a/apps/ui/src/app/api/public-proxy/[...slug]/route.ts
+++ b/apps/ui/src/app/api/public-proxy/[...slug]/route.ts
@@ -46,7 +46,17 @@ async function handler(
 
   const clonedRequest = request.clone()
   // Extract the body explicitly from the cloned request
-  const body = isReadOnly ? undefined : await clonedRequest.text()
+  let body: string | Blob | undefined
+  if (!isReadOnly) {
+    const contentType = clonedRequest.headers.get("content-type")
+    if (contentType?.includes("multipart/form-data")) {
+      // File upload - preserve FormData as blob
+      body = await clonedRequest.blob()
+    } else {
+      // Regular API call - use text for JSON
+      body = await clonedRequest.text()
+    }
+  }
 
   const authHeader = await createStrapiAuthHeader({
     isReadOnly,

--- a/apps/ui/src/lib/strapi-api/private.ts
+++ b/apps/ui/src/lib/strapi-api/private.ts
@@ -55,11 +55,13 @@ export class PrivateClient extends BaseStrapiClient {
       }
     }
 
+    const isFormData = requestInit?.body instanceof FormData
+
     return {
       url: completeUrl,
       headers: {
         Accept: "application/json",
-        "Content-Type": "application/json",
+        ...(isFormData ? {} : { "Content-type": "application/json" }),
         ...headers,
       },
     }

--- a/apps/ui/src/lib/strapi-api/public.ts
+++ b/apps/ui/src/lib/strapi-api/public.ts
@@ -51,11 +51,13 @@ export class PublicClient extends BaseStrapiClient {
       }
     }
 
+    const isFormData = requestInit?.body instanceof FormData
+
     return {
       url: completeUrl,
       headers: {
         Accept: "application/json",
-        "Content-type": "application/json",
+        ...(isFormData ? {} : { "Content-type": "application/json" }),
         ...headers,
       },
     }


### PR DESCRIPTION
Čau Tošo,

When using the fetchAPI through proxy it forces content-type causing request with form-data like /api/upload not working returning this error message.

<img width="635" height="196" alt="image" src="https://github.com/user-attachments/assets/68a99d5d-a3b4-477b-a387-783d3554c163" />
