### PR TITLE
chore(heroku postbuild): remove strapi and node modules cache from slug

### DIFF
--- a/scripts/heroku/heroku-postbuild.sh
+++ b/scripts/heroku/heroku-postbuild.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$APP" == "ui" ]; then
-    yarn build:ui
+    yarn build:ui && yarn build:ui && rm -rf apps/strapi .turbo node_modules/.cache
 elif [ "$APP" == "strapi" ]; then
     yarn build:strapi
 else


### PR DESCRIPTION
Čau Tošo,

I was unable to deploy this to Heroku because I was exceeding the hard slug size. Only types are needed from apps/strapi during build time so this folder can be deleted post-build to save space. Clearing the node_modules cache also helps.