### PR TITLE
fix: fixes an error when called on environemnts without nvm

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,6 @@ echo '🏗️👷 Styling your changes before committing 👷‍♂️🏗️'
 # Load nvm if available and use Node.js version from .nvmrc
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -f .nvmrc ] && nvm use
+[ -f .nvmrc ] && command -v nvm > /dev/null 2>&1 && nvm use
 
 git rev-parse -q --no-revs --verify MERGE_HEAD || npx lint-staged --verbose --concurrent false


### PR DESCRIPTION
Fixes following error, on environments without nvm

```
.husky/pre-commit: line 6: nvm: command not found
husky - pre-commit script failed (code 127)
husky - command not found in PATH=node_modules/.bin:/opt/homebrew/opt/git/libexec/git-core:/Users/jsimck/Projects/strapi-web-the-dawn-of-new-age/node_modules/.bin:/Users/jsimck/.cache/node/corepack/v1/pnpm/10.28.1/dist/node-gyp-bin:/Users/jsimck/Projects/strapi-web-the-dawn-of-new-age/node_modules/.bin:/opt/homebrew/share/fish/vendor_completions.d:/opt/homebrew/share/fish/completions:/Users/jsimck/.local/bin:/Users/jsimck/.local/share/mise/installs/node/22.21.1/bin:/Users/jsimck/.local/share/mise/installs/bun/1.3.4/bin:/Users/jsimck/.local/share/mise/installs/python/3.14.2/bin:/Users/jsimck/.local/share/mise/installs/npm-npm-check-updates/19.1.2/bin:/Users/jsimck/.local/share/mise/installs/npm-pnpm/10.24.0/bin:/Users/jsimck/.local/share/mise/installs/npm-yarn/1.22.22/bin:/Users/jsimck/.local/share/mise/installs/ruby/3.2.2/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Library/Apple/usr/bin:/usr/local/munki:/opt/homebrew/opt/mise/bin
git exited with error code 1
```