### PR TITLE
fix: docs deployment config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: apps/docs/build
+          path: apps/docs/build/strapi-next-monorepo-starter
 
   deploy:
     name: Deploy to GitHub Pages

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -3,7 +3,7 @@ import type { Config } from "@docusaurus/types"
 import type * as Preset from "@docusaurus/preset-classic"
 
 const url = process.env.DOCUSAURUS_URL ?? "https://notum-cz.github.io"
-const baseUrl = process.env.DOCUSAURUS_BASE_URL ?? "/"
+const baseUrl = process.env.DOCUSAURUS_BASE_URL ?? "/strapi-next-monorepo-starter/"
 
 const config: Config = {
   plugins: [
@@ -17,7 +17,9 @@ const config: Config = {
       },
     ],
   ],
-
+  organizationName: "notum-cz",
+  projectName: "strapi-next-monorepo-starter",
+  deploymentBranch: "main",
   title: "Strapi Next Monorepo Starter",
   tagline: "Enterprise-grade Strapi v5 + Next.js starter template",
   url,

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -19,7 +19,6 @@ const config: Config = {
   ],
   organizationName: "notum-cz",
   projectName: "strapi-next-monorepo-starter",
-  deploymentBranch: "main",
   title: "Strapi Next Monorepo Starter",
   tagline: "Enterprise-grade Strapi v5 + Next.js starter template",
   url,

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,5 +1,6 @@
 import { Redirect } from "@docusaurus/router"
+import useBaseUrl from "@docusaurus/useBaseUrl"
 
 export default function Home(): JSX.Element {
-  return <Redirect to="/docs/architecture" />
+  return <Redirect to={useBaseUrl("/docs/architecture")} />
 }


### PR DESCRIPTION
Fix deployment config for docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation redirect/navigation so links resolve correctly when the site is served from a subpath.

* **Chores**
  * Updated documentation deployment configuration and site base URL to serve the docs from /strapi-next-monorepo-starter/.
  * Added project/organization identifiers to the docs config for consistent deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->