### PR TITLE
fix: implement locale validation across layout and page components

### DIFF
--- a/apps/ui/src/app/[locale]/[[...rest]]/page.tsx
+++ b/apps/ui/src/app/[locale]/[[...rest]]/page.tsx
@@ -1,4 +1,5 @@
 import { ROOT_PAGE_PATH } from "@repo/shared-data"
+import { notFound } from "next/navigation"
 import type { Locale } from "next-intl"
 import { use } from "react"
 
@@ -6,6 +7,7 @@ import StrapiPageView from "@/components/layouts/StrapiPageView"
 import { createFallbackPath, debugStaticParams } from "@/lib/build"
 import { isDevelopment } from "@/lib/general-helpers"
 import { getMetadataFromStrapi } from "@/lib/metadata"
+import { isValidLocale } from "@/lib/navigation"
 import { fetchAllPages } from "@/lib/strapi-api/content/server"
 
 // Static/ISR page — no access to headers(), cookies(), or searchParams.
@@ -71,7 +73,10 @@ export async function generateMetadata(
   props: PageProps<"/[locale]/[[...rest]]">
 ) {
   const params = await props.params
-  const locale = params.locale as Locale
+  const locale = params.locale
+  if (!isValidLocale(locale)) {
+    return null
+  }
 
   const fullPath = ROOT_PAGE_PATH + (params.rest ?? []).join("/")
 
@@ -82,6 +87,9 @@ export default function StaticStrapiPage(
   props: PageProps<"/[locale]/[[...rest]]">
 ) {
   const params = use(props.params)
+  if (!isValidLocale(params.locale)) {
+    notFound()
+  }
 
   // `props.searchParams`` can't be accessed here because this is statically generated page
   // and searchParams are not available during build time

--- a/apps/ui/src/app/[locale]/dynamic/[[...rest]]/page.tsx
+++ b/apps/ui/src/app/[locale]/dynamic/[[...rest]]/page.tsx
@@ -1,9 +1,10 @@
 import { ROOT_PAGE_PATH } from "@repo/shared-data"
-import type { Locale } from "next-intl"
+import { notFound } from "next/navigation"
 import { use } from "react"
 
 import StrapiPageView from "@/components/layouts/StrapiPageView"
 import { getMetadataFromStrapi } from "@/lib/metadata"
+import { isValidLocale } from "@/lib/navigation"
 
 // Force dynamic rendering (SSR) for this route
 export const dynamic = "force-dynamic"
@@ -12,7 +13,10 @@ export async function generateMetadata(
   props: PageProps<"/[locale]/dynamic/[[...rest]]">
 ) {
   const params = await props.params
-  const locale = params.locale as Locale
+  const locale = params.locale
+  if (!isValidLocale(locale)) {
+    return null
+  }
 
   const fullPath = ROOT_PAGE_PATH + (params.rest ?? []).join("/")
 
@@ -23,6 +27,9 @@ export default function DynamicStrapiPage(
   props: PageProps<"/[locale]/dynamic/[[...rest]]">
 ) {
   const params = use(props.params)
+  if (!isValidLocale(params.locale)) {
+    notFound()
+  }
   // This is a dynamic page, so searchParams are available at runtime
   // and can be accessed here
   const searchParams = use(props.searchParams)

--- a/apps/ui/src/app/[locale]/layout.tsx
+++ b/apps/ui/src/app/[locale]/layout.tsx
@@ -3,7 +3,6 @@ import "@/styles/globals.css"
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 import Script from "next/script"
-import type { Locale } from "next-intl"
 import { setRequestLocale } from "next-intl/server"
 
 import { ErrorBoundary } from "@/components/elementary/ErrorBoundary"
@@ -17,7 +16,7 @@ import TrackingScripts from "@/components/providers/TrackingScripts"
 import { Toaster } from "@/components/ui/sonner"
 import { debugStaticParams } from "@/lib/build"
 import { fontRoboto } from "@/lib/fonts"
-import { routing } from "@/lib/navigation"
+import { isValidLocale, routing } from "@/lib/navigation"
 import { cn } from "@/lib/styles"
 
 export function generateStaticParams() {
@@ -38,15 +37,14 @@ export default async function RootLayout({
   children,
   params,
 }: LayoutProps<"/[locale]">) {
-  const { locale } = (await params) as { locale: Locale }
+  const { locale } = await params
 
+  if (!isValidLocale(locale)) {
+    notFound()
+  }
   // Enable static rendering
   // https://next-intl-docs.vercel.app/docs/getting-started/app-router/with-i18n-routing#static-rendering
   setRequestLocale(locale)
-
-  if (!routing.locales.includes(locale)) {
-    notFound()
-  }
 
   /**
    * This allows you to make following env variables RUNTIME.

--- a/apps/ui/src/lib/navigation.ts
+++ b/apps/ui/src/lib/navigation.ts
@@ -1,4 +1,5 @@
 import { normalizePageFullPath } from "@repo/shared-data"
+import { type Locale, hasLocale } from "next-intl"
 import { createNavigation } from "next-intl/navigation"
 import { defineRouting } from "next-intl/routing"
 
@@ -85,4 +86,14 @@ export const formatHref = (href: string | undefined | null): string => {
   }
 
   return href
+}
+
+/**
+ * Checks if a given locale is valid.
+ *
+ * @param locale
+ * @returns true if the locale is valid, false otherwise
+ */
+export const isValidLocale = (locale: string): locale is Locale => {
+  return hasLocale(routing.locales, locale)
 }


### PR DESCRIPTION
### Task Link
[Task #275](https://github.com/notum-cz/strapi-next-monorepo-starter/issues/275)

### Description
Add locale validation in layout and page components

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [x] **Reviewers** are set (team members who will review the code).
- [x] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [ ] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [ ] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [ ] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved locale validation to properly handle invalid language/region requests. The app now displays a 404 page when an unsupported locale is accessed, ensuring better error handling for international routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->