### PR TITLE
feat: add connect-form collection type with full CRUD support

### DIFF
--- a/EVENT_COLLECTION_STRUCTURE.md
+++ b/EVENT_COLLECTION_STRUCTURE.md
@@ -1,0 +1,190 @@
+# Events Collection Type Structure
+
+## How to Create in Your Strapi Admin
+
+**URL:** https://backend.apps.viswam.ai/admin/plugins/content-type-builder/content-types/api::event.event
+
+### Step 1: Create Collection Type
+
+- **Display name:** Event
+- **API ID:** event
+- **Collection name:** events
+
+### Step 2: Add Fields
+
+#### Basic Information
+
+1. **title** (String)
+   - Required: ✅ Yes
+   - Unique: ❌ No
+   - Translatable: ✅ Yes (enable i18n)
+
+2. **slug** (String)
+   - Required: ✅ Yes
+   - Unique: ✅ Yes
+   - Translatable: ❌ No
+
+3. **date** (Date)
+   - Required: ✅ Yes
+   - Date type: Date
+
+4. **time** (Time)
+   - Required: ❌ No
+
+5. **location** (String)
+   - Required: ❌ No
+   - Translatable: ✅ Yes (enable i18n)
+
+6. **description** (Rich Text)
+   - Required: ❌ No
+   - Translatable: ✅ Yes (enable i18n)
+
+#### Media
+
+7. **image** (Media)
+   - Required: ❌ No
+   - Multiple: ❌ No
+   - Allowed types: Images
+
+#### Links and Actions
+
+8. **cta_link** (Component)
+   - Component: utilities.link
+   - Required: ❌ No
+   - Repeatable: ❌ No
+
+#### Categorization
+
+9. **tags** (Component)
+   - Component: utilities.text
+   - Required: ❌ No
+   - Repeatable: ✅ Yes
+
+#### Additional Options
+
+10. **event_type** (Enumeration)
+    - Options: ["Conference", "Workshop", "Webinar", "Meetup", "Training", "Other"]
+    - Required: ❌ No
+
+11. **registration_required** (Boolean)
+    - Default: false
+    - Required: ❌ No
+
+12. **registration_link** (String)
+    - Required: ❌ No
+    - Translatable: ❌ No
+
+13. **featured** (Boolean)
+    - Default: false
+    - Required: ❌ No
+
+14. **capacity** (Integer)
+    - Required: ❌ No
+    - Min value: 1
+
+15. **price** (Decimal)
+    - Required: ❌ No
+    - Min value: 0
+
+### Step 3: Configure Advanced Settings
+
+#### General
+
+- **Draft & Publish:** ✅ Enabled
+- **Description:** "Event management for your website"
+
+#### i18n (Internationalization)
+
+- **Localized:** ✅ Yes
+- **Fields to translate:**
+  - title
+  - location
+  - description
+
+### Step 4: Save and Generate API
+
+Click **Save** to create the collection type. Strapi will automatically:
+
+- Generate the database schema
+- Create API endpoints
+- Update TypeScript types
+
+## API Endpoints Generated
+
+After creation, you'll have these endpoints:
+
+### GET Endpoints
+
+- `GET /api/events` - Get all events
+- `GET /api/events/:id` - Get single event
+- `GET /api/events/slug/:slug` - Get event by slug
+
+### POST Endpoints
+
+- `POST /api/events` - Create new event
+
+### PUT Endpoints
+
+- `PUT /api/events/:id` - Update event
+
+### DELETE Endpoints
+
+- `DELETE /api/events/:id` - Delete event
+
+## Example API Usage
+
+### Get All Events
+
+```bash
+curl "https://backend.apps.viswam.ai/api/events?populate=*"
+```
+
+### Get Single Event
+
+```bash
+curl "https://backend.apps.viswam.ai/api/events/1?populate=*"
+```
+
+### Create New Event
+
+```bash
+curl -X POST "https://backend.apps.viswam.ai/api/events" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "data": {
+      "title": "Tech Conference 2024",
+      "slug": "tech-conference-2024",
+      "date": "2024-06-15",
+      "time": "09:00:00",
+      "location": "San Francisco, CA",
+      "description": "Annual technology conference",
+      "event_type": "Conference",
+      "registration_required": true,
+      "featured": true
+    }
+  }'
+```
+
+## Frontend Integration
+
+Once created, you can fetch events in your frontend:
+
+```javascript
+// Example fetch function
+const fetchEvents = async () => {
+  const response = await fetch(
+    "https://backend.apps.viswam.ai/api/events?populate=*"
+  )
+  const data = await response.json()
+  return data.data
+}
+```
+
+## Notes
+
+1. **Enable i18n** for translatable fields if you need multiple languages
+2. **Set proper permissions** in Settings → Users & Permissions Plugin
+3. **Configure media upload** settings if using images
+4. **Test the API** using the API Documentation at `/admin/plugins/documentation`
+
+Would you like me to create the frontend React component to display these events once you've created the collection type in your Strapi admin?

--- a/FORM_COMPONENTS_GUIDE.md
+++ b/FORM_COMPONENTS_GUIDE.md
@@ -1,0 +1,174 @@
+# Form Components Field Guide
+
+## 1. Contact Form
+
+**Component:** `forms.contact-form`
+**Fields:**
+
+- Name (string, required)
+- Email (email, required)
+- Phone (string, optional)
+- Subject (string, optional)
+- Message (text, required)
+- Consent checkbox (boolean, required)
+- Submit button text (string, optional)
+
+## 2. Newsletter Signup Form
+
+**Component:** `forms.newsletter-form`
+**Fields:**
+
+- Title (string, optional)
+- Subtitle (string, optional)
+- Email field label (string, optional)
+- Success message (string, optional)
+- Privacy policy text (string, optional)
+- Submit button text (string, optional)
+
+## 3. Event Registration Form
+
+**Component:** `forms.event-registration`
+**Fields:**
+
+- Event name (string, required)
+- Participant name (string, required)
+- Email (email, required)
+- Phone (string, required)
+- Number of attendees (number, optional)
+- Dietary restrictions (text, optional)
+- Special requirements (text, optional)
+- Agreement to terms (boolean, required)
+
+## 4. Job Application Form
+
+**Component:** `forms.job-application`
+**Fields:**
+
+- Position title (string, required)
+- Full name (string, required)
+- Email (email, required)
+- Phone (string, required)
+- Resume/CV (file upload, required)
+- Cover letter (text, optional)
+- LinkedIn profile (string, optional)
+- Years of experience (number, optional)
+- Availability date (date, optional)
+- Salary expectations (string, optional)
+
+## 5. Quote Request Form
+
+**Component:** `forms.quote-request`
+**Fields:**
+
+- Service type (enumeration: ["Web Design", "Development", "Consulting", "Other"])
+- Company name (string, optional)
+- Contact person (string, required)
+- Email (email, required)
+- Phone (string, required)
+- Project description (text, required)
+- Budget range (enumeration: ["Under $1000", "$1000-$5000", "$5000-$10000", "Over $10000", "Not sure"])
+- Timeline (string, optional)
+- Additional requirements (text, optional)
+
+## 6. Feedback/Survey Form
+
+**Component:** `forms.feedback-survey`
+**Fields:**
+
+- Survey title (string, required)
+- Overall rating (number 1-5, required)
+- Service quality rating (number 1-5, optional)
+- Staff friendliness rating (number 1-5, optional)
+- Comments (text, optional)
+- Would recommend (boolean, optional)
+- Contact for follow-up (boolean, optional)
+- Contact email (email, conditional)
+
+## 7. Booking/Appointment Form
+
+**Component:** `forms.booking-appointment`
+**Fields:**
+
+- Service type (string, required)
+- Full name (string, required)
+- Email (email, required)
+- Phone (string, required)
+- Preferred date (date, required)
+- Preferred time (time, required)
+- Additional notes (text, optional)
+- Confirmation email (boolean, optional)
+
+## 8. Product Inquiry Form
+
+**Component:** `forms.product-inquiry`
+**Fields:**
+
+- Product name (string, required)
+- Customer name (string, required)
+- Email (email, required)
+- Phone (string, optional)
+- Company name (string, optional)
+- Quantity needed (number, optional)
+- Budget (string, optional)
+- Project timeline (string, optional)
+- Additional questions (text, optional)
+
+## 9. Support Ticket Form
+
+**Component:** `forms.support-ticket`
+**Fields:**
+
+- Issue type (enumeration: ["Technical", "Billing", "Account", "Feature Request", "Other"])
+- Priority level (enumeration: ["Low", "Medium", "High", "Critical"])
+- Subject (string, required)
+- Description (text, required)
+- Contact email (email, required)
+- Contact phone (string, optional)
+- Account number (string, optional)
+- Screenshots (file upload, optional)
+
+## 10. Partner/Vendor Registration Form
+
+**Component:** `forms.partner-registration`
+**Fields:**
+
+- Company name (string, required)
+- Contact person (string, required)
+- Company email (email, required)
+- Company phone (string, required)
+- Website URL (string, optional)
+- Business type (enumeration: ["Manufacturer", "Distributor", "Service Provider", "Retailer"])
+- Annual revenue (enumeration: ["Under $100K", "$100K-$500K", "$500K-$1M", "Over $1M"])
+- Number of employees (enumeration: ["1-10", "11-50", "51-200", "200+"])
+- Description of business (text, required)
+- References (text, optional)
+
+## Common Form Elements to Include:
+
+### Basic Fields:
+
+- Text inputs (name, email, phone, company)
+- Text areas (message, description, comments)
+- Select dropdowns (categories, options)
+- Radio buttons (single choice)
+- Checkboxes (multiple choices, agreements)
+- File uploads (documents, images)
+- Date/time pickers
+
+### Validation Fields:
+
+- Required field indicators
+- Email format validation
+- Phone number format
+- Character limits
+- File type restrictions
+
+### Styling Options:
+
+- Form title and subtitle
+- Submit button text and styling
+- Success/error messages
+- Background colors
+- Layout options (single column, multi-column)
+
+Would you like me to create any of these specific form components for you?

--- a/apps/strapi/sample-event-data.json
+++ b/apps/strapi/sample-event-data.json
@@ -1,0 +1,33 @@
+{
+  "event": {
+    "title": "From Code to Creativity – A stakeholder consultation event on responsible AI development and governance in India",
+    "slug": "from-code-to-creativity-stakeholder-consultation-2026",
+    "subtitle": "Understanding Trust and Safety in AI",
+    "date": "2026-01-31",
+    "time": "09:30:00",
+    "location": "IIIT Hyderabad",
+    "description": "VISWAM.AI, SFLC.in, FOSS United, and The Linux Foundation are jointly organising this in-person stakeholder consultation event.\n\nThe event brings together policymakers, industry leaders, open-source practitioners, creators, and civil society to examine how trust, safety, and accountability can be embedded into AI systems from the stage of design and training. Two closed-door roundtable discussions will focus on critical governance questions shaping India's AI ecosystem.",
+    "organizers": "VISWAM.AI, SFLC.in, FOSS United, and The Linux Foundation",
+    "registrationRequired": true,
+    "registrationLink": "https://forms.example.com/register",
+    "eventType": "Consultation",
+    "featured": true,
+    "participationOptions": "Available both in-person at IIIT Hyderabad and online",
+    "roundtableSessions": [
+      {
+        "title": "Harnessing Open Source AI",
+        "description": "Examining the role of open-source AI in building transparent, accountable, and inclusive AI systems. Critically exploring what \"open\" means in the context of AI models, data, licensing, safety, and governance."
+      },
+      {
+        "title": "Balancing AI Innovation and Copyright",
+        "description": "Deliberating on the DPIIT Working Paper on Generative AI and Copyright, including the proposed hybrid licensing model and its implications for AI developers, creators, and India's AI ecosystem."
+      }
+    ],
+    "tags": [
+      { "text": "AI Governance" },
+      { "text": "Trust & Safety" },
+      { "text": "Open Source" },
+      { "text": "India" }
+    ]
+  }
+}

--- a/apps/strapi/src/api/connect-form/content-types/connect-form/schema.json
+++ b/apps/strapi/src/api/connect-form/content-types/connect-form/schema.json
@@ -1,0 +1,81 @@
+{
+  "kind": "collectionType",
+  "collectionName": "connect_forms",
+  "info": {
+    "singularName": "connect-form",
+    "pluralName": "connect-forms",
+    "displayName": "Connect Form",
+    "description": "Contact form submissions with dynamic fields"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "required": true
+    },
+    "phone": {
+      "type": "string",
+      "required": true
+    },
+    "company": {
+      "type": "string"
+    },
+    "message": {
+      "type": "text"
+    },
+    "description": {
+      "type": "text"
+    },
+    "comments": {
+      "type": "text"
+    },
+    "category": {
+      "type": "enumeration",
+      "enum": [
+        "general",
+        "sales",
+        "support",
+        "partnership",
+        "feedback",
+        "other"
+      ]
+    },
+    "priority": {
+      "type": "enumeration",
+      "enum": ["low", "medium", "high", "urgent"]
+    },
+    "interests": {
+      "type": "json",
+      "default": []
+    },
+    "agreeTerms": {
+      "type": "boolean",
+      "default": false
+    },
+    "agreePrivacy": {
+      "type": "boolean",
+      "default": false
+    },
+    "preferredDate": {
+      "type": "datetime"
+    },
+    "document": {
+      "type": "media",
+      "multiple": true,
+      "required": false,
+      "allowedTypes": ["files", "images", "videos"]
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": ["new", "in_progress", "resolved", "closed"],
+      "default": "new"
+    }
+  }
+}

--- a/apps/strapi/src/api/connect-form/controllers/connect-form.ts
+++ b/apps/strapi/src/api/connect-form/controllers/connect-form.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreController("api::connect-form.connect-form")

--- a/apps/strapi/src/api/connect-form/routes/connect-form.ts
+++ b/apps/strapi/src/api/connect-form/routes/connect-form.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreRouter("api::connect-form.connect-form")

--- a/apps/strapi/src/api/connect-form/services/connect-form.ts
+++ b/apps/strapi/src/api/connect-form/services/connect-form.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreService("api::connect-form.connect-form")

--- a/apps/strapi/src/api/event/content-types/event/schema.json
+++ b/apps/strapi/src/api/event/content-types/event/schema.json
@@ -1,0 +1,161 @@
+{
+  "kind": "collectionType",
+  "collectionName": "events",
+  "info": {
+    "singularName": "event",
+    "pluralName": "events",
+    "displayName": "Event",
+    "description": "Event management for your website"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "required": true
+    },
+    "slug": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "required": true,
+      "unique": true,
+      "regex": "^[a-z0-9/-]+$"
+    },
+    "subtitle": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "date": {
+      "type": "date",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "required": true
+    },
+    "time": {
+      "type": "time",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "location": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "description": {
+      "type": "richtext",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images", "videos"],
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "organizers": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "registrationRequired": {
+      "type": "boolean",
+      "default": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "registrationLink": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "ctaLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "utilities.link"
+    },
+    "tags": {
+      "type": "component",
+      "repeatable": true,
+      "component": "utilities.text"
+    },
+    "eventType": {
+      "type": "enumeration",
+      "enum": ["Conference", "Workshop", "Webinar", "Meetup", "Training", "Consultation", "Roundtable", "Other"]
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "capacity": {
+      "type": "integer",
+      "min": 1
+    },
+    "price": {
+      "type": "decimal",
+      "min": 0
+    },
+    "roundtableSessions": {
+      "type": "component",
+      "repeatable": true,
+      "component": "elements.event-session"
+    },
+    "participationOptions": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/apps/strapi/src/api/event/controllers/event.ts
+++ b/apps/strapi/src/api/event/controllers/event.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreController("api::event.event")

--- a/apps/strapi/src/api/event/routes/event.ts
+++ b/apps/strapi/src/api/event/routes/event.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreRouter("api::event.event")

--- a/apps/strapi/src/api/event/services/event.ts
+++ b/apps/strapi/src/api/event/services/event.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreService("api::event.event")

--- a/apps/strapi/src/api/form-submission/content-types/form-submission/schema.json
+++ b/apps/strapi/src/api/form-submission/content-types/form-submission/schema.json
@@ -1,0 +1,48 @@
+{
+  "kind": "collectionType",
+  "collectionName": "form_submissions",
+  "info": {
+    "singularName": "form-submission",
+    "pluralName": "form-submissions",
+    "displayName": "Form Submission"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "pluginOptions": {},
+  "attributes": {
+    "fullName": {
+      "type": "string",
+      "required": true
+    },
+    "email": {
+      "type": "email",
+      "required": true
+    },
+    "phone": {
+      "type": "string",
+      "required": true
+    },
+    "formType": {
+      "type": "enumeration",
+      "enum": [
+        "contact",
+        "newsletter",
+        "internship",
+        "event",
+        "job_application",
+        "quote_request",
+        "feedback",
+        "booking",
+        "product_inquiry",
+        "partner_registration"
+      ],
+      "required": true
+    },
+    "dynamicSections": {
+      "type": "component",
+      "repeatable": false,
+      "component": "forms.dynamic-sections"
+    }
+  }
+}

--- a/apps/strapi/src/api/page/content-types/page/schema.json
+++ b/apps/strapi/src/api/page/content-types/page/schema.json
@@ -68,6 +68,7 @@
         "sections.faq",
         "sections.carousel",
         "sections.animated-logo-row",
+        "sections.events",
         "forms.newsletter-form",
         "forms.contact-form",
         "utilities.ck-editor-content",

--- a/apps/strapi/src/components/elements/event-item.json
+++ b/apps/strapi/src/components/elements/event-item.json
@@ -1,0 +1,57 @@
+{
+  "collectionName": "components_elements_event_items",
+  "info": {
+    "displayName": "Event Item",
+    "description": "Individual event with date, title, description, and optional image"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "date": {
+      "type": "date",
+      "required": true
+    },
+    "time": {
+      "type": "time"
+    },
+    "location": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "description": {
+      "type": "richtext",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "image": {
+      "type": "component",
+      "repeatable": false,
+      "component": "utilities.basic-image"
+    },
+    "ctaLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "utilities.link"
+    },
+    "tags": {
+      "type": "component",
+      "repeatable": true,
+      "component": "utilities.text"
+    }
+  }
+}

--- a/apps/strapi/src/components/elements/event-session.json
+++ b/apps/strapi/src/components/elements/event-session.json
@@ -1,0 +1,32 @@
+{
+  "collectionName": "components_elements_event_sessions",
+  "info": {
+    "displayName": "Event Session",
+    "description": "Individual session/roundtable within an event"
+  },
+  "options": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "description": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/apps/strapi/src/components/forms/dynamic-sections.json
+++ b/apps/strapi/src/components/forms/dynamic-sections.json
@@ -1,0 +1,30 @@
+{
+  "collectionName": "components_forms_dynamic_sections",
+  "info": {
+    "displayName": "DynamicSections",
+    "description": "Container for conditional form sections based on form_type"
+  },
+  "options": {},
+  "attributes": {
+    "internshipDetails": {
+      "type": "component",
+      "repeatable": false,
+      "component": "forms.internship-details"
+    },
+    "eventDetails": {
+      "type": "component",
+      "repeatable": false,
+      "component": "forms.event-details"
+    },
+    "jobApplicationDetails": {
+      "type": "component",
+      "repeatable": false,
+      "component": "forms.job-application-details"
+    },
+    "generalMessage": {
+      "type": "component",
+      "repeatable": false,
+      "component": "forms.general-message"
+    }
+  }
+}

--- a/apps/strapi/src/components/forms/event-details.json
+++ b/apps/strapi/src/components/forms/event-details.json
@@ -1,0 +1,22 @@
+{
+  "collectionName": "components_forms_event_details",
+  "info": {
+    "displayName": "EventDetails",
+    "description": "Conditional section for event form type"
+  },
+  "options": {},
+  "attributes": {
+    "eventName": {
+      "type": "string"
+    },
+    "numberOfAttendees": {
+      "type": "integer"
+    },
+    "dietaryRestrictions": {
+      "type": "text"
+    },
+    "specialRequirements": {
+      "type": "text"
+    }
+  }
+}

--- a/apps/strapi/src/components/forms/general-message.json
+++ b/apps/strapi/src/components/forms/general-message.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_forms_general_message",
+  "info": {
+    "displayName": "GeneralMessage",
+    "description": "Conditional section for general contact/message form type"
+  },
+  "options": {},
+  "attributes": {
+    "subject": {
+      "type": "string"
+    },
+    "message": {
+      "type": "text"
+    }
+  }
+}

--- a/apps/strapi/src/components/forms/internship-details.json
+++ b/apps/strapi/src/components/forms/internship-details.json
@@ -1,0 +1,27 @@
+{
+  "collectionName": "components_forms_internship_details",
+  "info": {
+    "displayName": "InternshipDetails",
+    "description": "Conditional section for internship form type"
+  },
+  "options": {},
+  "attributes": {
+    "collegeName": {
+      "type": "string"
+    },
+    "degree": {
+      "type": "string"
+    },
+    "yearOfStudy": {
+      "type": "string"
+    },
+    "skills": {
+      "type": "text"
+    },
+    "resume": {
+      "allowedTypes": ["files"],
+      "type": "media",
+      "multiple": false
+    }
+  }
+}

--- a/apps/strapi/src/components/forms/job-application-details.json
+++ b/apps/strapi/src/components/forms/job-application-details.json
@@ -1,0 +1,24 @@
+{
+  "collectionName": "components_forms_job_application_details",
+  "info": {
+    "displayName": "JobApplicationDetails",
+    "description": "Conditional section for job application form type"
+  },
+  "options": {},
+  "attributes": {
+    "positionTitle": {
+      "type": "string"
+    },
+    "resume": {
+      "allowedTypes": ["files"],
+      "type": "media",
+      "multiple": false
+    },
+    "coverLetter": {
+      "type": "text"
+    },
+    "yearsOfExperience": {
+      "type": "integer"
+    }
+  }
+}

--- a/apps/strapi/src/components/sections/events.json
+++ b/apps/strapi/src/components/sections/events.json
@@ -1,0 +1,72 @@
+{
+  "collectionName": "components_sections_events",
+  "info": {
+    "displayName": "Events",
+    "description": "Display a list of events with date, title, description, and optional image"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "subtitle": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "events": {
+      "type": "component",
+      "repeatable": true,
+      "component": "elements.event-item",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "layout": {
+      "type": "enumeration",
+      "enum": ["grid", "list"],
+      "default": "grid",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "columns": {
+      "type": "integer",
+      "default": 3,
+      "min": 1,
+      "max": 4,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "showFilters": {
+      "type": "boolean",
+      "default": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "bgColor": {
+      "type": "customField",
+      "regex": "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$",
+      "customField": "plugin::color-picker.color"
+    }
+  }
+}

--- a/apps/strapi/src/populateDynamicZone/sections/events.ts
+++ b/apps/strapi/src/populateDynamicZone/sections/events.ts
@@ -1,0 +1,14 @@
+import basicImagePopulate from "../utilities/basic-image"
+import linkPopulate from "../utilities/link"
+
+export default {
+  populate: {
+    events: {
+      populate: {
+        image: basicImagePopulate,
+        ctaLink: linkPopulate,
+        tags: true,
+      },
+    },
+  },
+}

--- a/apps/strapi/types/generated/components.d.ts
+++ b/apps/strapi/types/generated/components.d.ts
@@ -1,29 +1,23 @@
 import type { Schema, Struct } from "@strapi/strapi"
 
-export interface ElementsEventItem extends Struct.ComponentSchema {
-  collectionName: "components_elements_event_items"
+export interface ElementsEventSession extends Struct.ComponentSchema {
+  collectionName: "components_elements_event_sessions"
   info: {
-    description: "Individual event with date, title, description, and optional image"
-    displayName: "Event Item"
+    description: "Individual session/roundtable within an event"
+    displayName: "Event Session"
+  }
+  pluginOptions: {
+    i18n: {
+      localized: true
+    }
   }
   attributes: {
-    ctaLink: Schema.Attribute.Component<"utilities.link", false>
-    date: Schema.Attribute.Date & Schema.Attribute.Required
-    description: Schema.Attribute.RichText &
+    description: Schema.Attribute.Text &
       Schema.Attribute.SetPluginOptions<{
         i18n: {
           localized: true
         }
       }>
-    image: Schema.Attribute.Component<"utilities.basic-image", false>
-    location: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }>
-    tags: Schema.Attribute.Component<"utilities.text", true>
-    time: Schema.Attribute.Time
     title: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
@@ -91,65 +85,6 @@ export interface SectionsCarousel extends Struct.ComponentSchema {
   attributes: {
     images: Schema.Attribute.Component<"utilities.image-with-link", true>
     radius: Schema.Attribute.Enumeration<["sm", "md", "lg", "xl", "full"]>
-  }
-}
-
-export interface SectionsEvents extends Struct.ComponentSchema {
-  collectionName: "components_sections_events"
-  info: {
-    description: "Display a list of events with date, title, description, and optional image"
-    displayName: "Events"
-  }
-  attributes: {
-    bgColor: Schema.Attribute.String &
-      Schema.Attribute.CustomField<"plugin::color-picker.color">
-    columns: Schema.Attribute.Integer &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }> &
-      Schema.Attribute.SetMinMax<
-        {
-          max: 4
-          min: 1
-        },
-        number
-      > &
-      Schema.Attribute.DefaultTo<3>
-    events: Schema.Attribute.Component<"elements.event-item", true> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }>
-    layout: Schema.Attribute.Enumeration<["grid", "list"]> &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }> &
-      Schema.Attribute.DefaultTo<"grid">
-    showFilters: Schema.Attribute.Boolean &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }> &
-      Schema.Attribute.DefaultTo<true>
-    subtitle: Schema.Attribute.String &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }>
-    title: Schema.Attribute.String &
-      Schema.Attribute.Required &
-      Schema.Attribute.SetPluginOptions<{
-        i18n: {
-          localized: true
-        }
-      }>
   }
 }
 
@@ -469,13 +404,12 @@ export interface UtilitiesTipTapRichText extends Struct.ComponentSchema {
 declare module "@strapi/strapi" {
   export module Public {
     export interface ComponentSchemas {
-      "elements.event-item": ElementsEventItem
+      "elements.event-session": ElementsEventSession
       "elements.footer-item": ElementsFooterItem
       "forms.contact-form": FormsContactForm
       "forms.newsletter-form": FormsNewsletterForm
       "sections.animated-logo-row": SectionsAnimatedLogoRow
       "sections.carousel": SectionsCarousel
-      "sections.events": SectionsEvents
       "sections.faq": SectionsFaq
       "sections.heading-with-cta-button": SectionsHeadingWithCtaButton
       "sections.hero": SectionsHero

--- a/apps/strapi/types/generated/components.d.ts
+++ b/apps/strapi/types/generated/components.d.ts
@@ -1,5 +1,39 @@
 import type { Schema, Struct } from "@strapi/strapi"
 
+export interface ElementsEventItem extends Struct.ComponentSchema {
+  collectionName: "components_elements_event_items"
+  info: {
+    description: "Individual event with date, title, description, and optional image"
+    displayName: "Event Item"
+  }
+  attributes: {
+    ctaLink: Schema.Attribute.Component<"utilities.link", false>
+    date: Schema.Attribute.Date & Schema.Attribute.Required
+    description: Schema.Attribute.RichText &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    image: Schema.Attribute.Component<"utilities.basic-image", false>
+    location: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    tags: Schema.Attribute.Component<"utilities.text", true>
+    time: Schema.Attribute.Time
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+  }
+}
+
 export interface ElementsFooterItem extends Struct.ComponentSchema {
   collectionName: "components_elements_footer_items"
   info: {
@@ -57,6 +91,65 @@ export interface SectionsCarousel extends Struct.ComponentSchema {
   attributes: {
     images: Schema.Attribute.Component<"utilities.image-with-link", true>
     radius: Schema.Attribute.Enumeration<["sm", "md", "lg", "xl", "full"]>
+  }
+}
+
+export interface SectionsEvents extends Struct.ComponentSchema {
+  collectionName: "components_sections_events"
+  info: {
+    description: "Display a list of events with date, title, description, and optional image"
+    displayName: "Events"
+  }
+  attributes: {
+    bgColor: Schema.Attribute.String &
+      Schema.Attribute.CustomField<"plugin::color-picker.color">
+    columns: Schema.Attribute.Integer &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
+      Schema.Attribute.SetMinMax<
+        {
+          max: 4
+          min: 1
+        },
+        number
+      > &
+      Schema.Attribute.DefaultTo<3>
+    events: Schema.Attribute.Component<"elements.event-item", true> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    layout: Schema.Attribute.Enumeration<["grid", "list"]> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
+      Schema.Attribute.DefaultTo<"grid">
+    showFilters: Schema.Attribute.Boolean &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }> &
+      Schema.Attribute.DefaultTo<true>
+    subtitle: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
   }
 }
 
@@ -376,11 +469,13 @@ export interface UtilitiesTipTapRichText extends Struct.ComponentSchema {
 declare module "@strapi/strapi" {
   export module Public {
     export interface ComponentSchemas {
+      "elements.event-item": ElementsEventItem
       "elements.footer-item": ElementsFooterItem
       "forms.contact-form": FormsContactForm
       "forms.newsletter-form": FormsNewsletterForm
       "sections.animated-logo-row": SectionsAnimatedLogoRow
       "sections.carousel": SectionsCarousel
+      "sections.events": SectionsEvents
       "sections.faq": SectionsFaq
       "sections.heading-with-cta-button": SectionsHeadingWithCtaButton
       "sections.hero": SectionsHero

--- a/apps/strapi/types/generated/contentTypes.d.ts
+++ b/apps/strapi/types/generated/contentTypes.d.ts
@@ -228,6 +228,7 @@ export interface AdminSession extends Struct.CollectionTypeSchema {
   }
   attributes: {
     absoluteExpiresAt: Schema.Attribute.DateTime & Schema.Attribute.Private
+    childId: Schema.Attribute.String & Schema.Attribute.Private
     createdAt: Schema.Attribute.DateTime
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private
@@ -237,7 +238,6 @@ export interface AdminSession extends Struct.CollectionTypeSchema {
     expiresAt: Schema.Attribute.DateTime &
       Schema.Attribute.Required &
       Schema.Attribute.Private
-    childId: Schema.Attribute.String & Schema.Attribute.Private
     locale: Schema.Attribute.String & Schema.Attribute.Private
     localizations: Schema.Attribute.Relation<"oneToMany", "admin::session"> &
       Schema.Attribute.Private
@@ -587,6 +587,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
+    children: Schema.Attribute.Relation<"oneToMany", "api::page.page">
     content: Schema.Attribute.DynamicZone<
       [
         "sections.image-with-cta-button",
@@ -596,6 +597,7 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
         "sections.faq",
         "sections.carousel",
         "sections.animated-logo-row",
+        "sections.events",
         "forms.newsletter-form",
         "forms.contact-form",
         "utilities.ck-editor-content",
@@ -618,7 +620,6 @@ export interface ApiPagePage extends Struct.CollectionTypeSchema {
           localized: true
         }
       }>
-    children: Schema.Attribute.Relation<"oneToMany", "api::page.page">
     locale: Schema.Attribute.String
     localizations: Schema.Attribute.Relation<"oneToMany", "api::page.page">
     parent: Schema.Attribute.Relation<"manyToOne", "api::page.page">
@@ -1027,11 +1028,11 @@ export interface PluginUploadFolder extends Struct.CollectionTypeSchema {
     }
   }
   attributes: {
+    children: Schema.Attribute.Relation<"oneToMany", "plugin::upload.folder">
     createdAt: Schema.Attribute.DateTime
     createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private
     files: Schema.Attribute.Relation<"oneToMany", "plugin::upload.file">
-    children: Schema.Attribute.Relation<"oneToMany", "plugin::upload.folder">
     locale: Schema.Attribute.String & Schema.Attribute.Private
     localizations: Schema.Attribute.Relation<
       "oneToMany",

--- a/apps/strapi/types/generated/contentTypes.d.ts
+++ b/apps/strapi/types/generated/contentTypes.d.ts
@@ -430,6 +430,199 @@ export interface AdminUser extends Struct.CollectionTypeSchema {
   }
 }
 
+export interface ApiConnectFormConnectForm extends Struct.CollectionTypeSchema {
+  collectionName: "connect_forms"
+  info: {
+    description: "Contact form submissions with dynamic fields"
+    displayName: "Connect Form"
+    pluralName: "connect-forms"
+    singularName: "connect-form"
+  }
+  options: {
+    draftAndPublish: false
+  }
+  attributes: {
+    agreePrivacy: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>
+    agreeTerms: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>
+    category: Schema.Attribute.Enumeration<
+      ["general", "sales", "support", "partnership", "feedback", "other"]
+    >
+    comments: Schema.Attribute.Text
+    company: Schema.Attribute.String
+    createdAt: Schema.Attribute.DateTime
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private
+    description: Schema.Attribute.Text
+    document: Schema.Attribute.Media<"files" | "images" | "videos", true>
+    email: Schema.Attribute.Email & Schema.Attribute.Required
+    interests: Schema.Attribute.JSON & Schema.Attribute.DefaultTo<[]>
+    locale: Schema.Attribute.String & Schema.Attribute.Private
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::connect-form.connect-form"
+    > &
+      Schema.Attribute.Private
+    message: Schema.Attribute.Text
+    name: Schema.Attribute.String & Schema.Attribute.Required
+    phone: Schema.Attribute.String & Schema.Attribute.Required
+    preferredDate: Schema.Attribute.DateTime
+    priority: Schema.Attribute.Enumeration<["low", "medium", "high", "urgent"]>
+    publishedAt: Schema.Attribute.DateTime
+    status: Schema.Attribute.Enumeration<
+      ["new", "in_progress", "resolved", "closed"]
+    > &
+      Schema.Attribute.DefaultTo<"new">
+    updatedAt: Schema.Attribute.DateTime
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private
+  }
+}
+
+export interface ApiEventEvent extends Struct.CollectionTypeSchema {
+  collectionName: "events"
+  info: {
+    description: "Event management for your website"
+    displayName: "Event"
+    pluralName: "events"
+    singularName: "event"
+  }
+  options: {
+    draftAndPublish: true
+  }
+  pluginOptions: {
+    i18n: {
+      localized: true
+    }
+  }
+  attributes: {
+    capacity: Schema.Attribute.Integer &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 1
+        },
+        number
+      >
+    createdAt: Schema.Attribute.DateTime
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private
+    ctaLink: Schema.Attribute.Component<"utilities.link", false>
+    date: Schema.Attribute.Date &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }>
+    description: Schema.Attribute.RichText &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    eventType: Schema.Attribute.Enumeration<
+      [
+        "Conference",
+        "Workshop",
+        "Webinar",
+        "Meetup",
+        "Training",
+        "Consultation",
+        "Roundtable",
+        "Other",
+      ]
+    >
+    featured: Schema.Attribute.Boolean &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }> &
+      Schema.Attribute.DefaultTo<false>
+    image: Schema.Attribute.Media<"images" | "videos"> &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }>
+    locale: Schema.Attribute.String
+    localizations: Schema.Attribute.Relation<"oneToMany", "api::event.event">
+    location: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    organizers: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    participationOptions: Schema.Attribute.Text &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    price: Schema.Attribute.Decimal &
+      Schema.Attribute.SetMinMax<
+        {
+          min: 0
+        },
+        number
+      >
+    publishedAt: Schema.Attribute.DateTime
+    registrationLink: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }>
+    registrationRequired: Schema.Attribute.Boolean &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }> &
+      Schema.Attribute.DefaultTo<false>
+    roundtableSessions: Schema.Attribute.Component<
+      "elements.event-session",
+      true
+    >
+    slug: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.Unique &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }>
+    subtitle: Schema.Attribute.String &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    tags: Schema.Attribute.Component<"utilities.text", true>
+    time: Schema.Attribute.Time &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: false
+        }
+      }>
+    title: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetPluginOptions<{
+        i18n: {
+          localized: true
+        }
+      }>
+    updatedAt: Schema.Attribute.DateTime
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private
+  }
+}
+
 export interface ApiFooterFooter extends Struct.SingleTypeSchema {
   collectionName: "footers"
   info: {
@@ -477,6 +670,53 @@ export interface ApiFooterFooter extends Struct.SingleTypeSchema {
           localized: true
         }
       }>
+    updatedAt: Schema.Attribute.DateTime
+    updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private
+  }
+}
+
+export interface ApiFormSubmissionFormSubmission
+  extends Struct.CollectionTypeSchema {
+  collectionName: "form_submissions"
+  info: {
+    displayName: "Form Submission"
+    pluralName: "form-submissions"
+    singularName: "form-submission"
+  }
+  options: {
+    draftAndPublish: false
+  }
+  attributes: {
+    createdAt: Schema.Attribute.DateTime
+    createdBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
+      Schema.Attribute.Private
+    dynamicSections: Schema.Attribute.Component<"forms.dynamic-sections", false>
+    email: Schema.Attribute.Email & Schema.Attribute.Required
+    formType: Schema.Attribute.Enumeration<
+      [
+        "contact",
+        "newsletter",
+        "internship",
+        "event",
+        "job_application",
+        "quote_request",
+        "feedback",
+        "booking",
+        "product_inquiry",
+        "partner_registration",
+      ]
+    > &
+      Schema.Attribute.Required
+    fullName: Schema.Attribute.String & Schema.Attribute.Required
+    locale: Schema.Attribute.String & Schema.Attribute.Private
+    localizations: Schema.Attribute.Relation<
+      "oneToMany",
+      "api::form-submission.form-submission"
+    > &
+      Schema.Attribute.Private
+    phone: Schema.Attribute.String & Schema.Attribute.Required
+    publishedAt: Schema.Attribute.DateTime
     updatedAt: Schema.Attribute.DateTime
     updatedBy: Schema.Attribute.Relation<"oneToOne", "admin::user"> &
       Schema.Attribute.Private
@@ -1223,7 +1463,10 @@ declare module "@strapi/strapi" {
       "admin::transfer-token": AdminTransferToken
       "admin::transfer-token-permission": AdminTransferTokenPermission
       "admin::user": AdminUser
+      "api::connect-form.connect-form": ApiConnectFormConnectForm
+      "api::event.event": ApiEventEvent
       "api::footer.footer": ApiFooterFooter
+      "api::form-submission.form-submission": ApiFormSubmissionFormSubmission
       "api::internal-job.internal-job": ApiInternalJobInternalJob
       "api::navbar.navbar": ApiNavbarNavbar
       "api::page.page": ApiPagePage

--- a/apps/ui/src/components/page-builder/components/sections/StrapiEvents.tsx
+++ b/apps/ui/src/components/page-builder/components/sections/StrapiEvents.tsx
@@ -1,0 +1,187 @@
+import type { Data } from "@repo/strapi-types"
+import { Calendar, Clock, MapPin, Tag } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { cn } from "@/lib/styles"
+
+interface StrapiEventsProps {
+  readonly component: Data.Component<"sections.events">
+}
+
+function formatDate(dateString: string | Date) {
+  const date = new Date(dateString)
+
+  return date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  })
+}
+
+function formatTime(timeString: string) {
+  if (!timeString) return ""
+  const [hours, minutes] = timeString.split(":")
+  const date = new Date()
+  date.setHours(Number.parseInt(hours || "0", 10))
+  date.setMinutes(Number.parseInt(minutes || "0", 10))
+
+  return date.toLocaleTimeString("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+export function StrapiEvents({ component }: StrapiEventsProps) {
+  const {
+    title,
+    subtitle,
+    events,
+    layout = "grid",
+    columns = 3,
+    showFilters = true,
+    bgColor,
+  } = component
+
+  if (!events || events.length === 0) {
+    return null
+  }
+
+  const getGridColumns = () => {
+    switch (columns) {
+      case 1:
+        return "grid-cols-1"
+      case 2:
+        return "grid-cols-1 md:grid-cols-2"
+      case 3:
+        return "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+      case 4:
+        return "grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+
+      default:
+        return "grid-cols-1 md:grid-cols-2 lg:grid-cols-3"
+    }
+  }
+
+  return (
+    <section
+      className={cn(
+        "py-12",
+        bgColor && bgColor !== "null" ? `bg-[${bgColor}]` : ""
+      )}
+      style={{
+        backgroundColor: bgColor && bgColor !== "null" ? bgColor : undefined,
+      }}
+    >
+      <div className="container mx-auto px-4">
+        <div className="mb-12 text-center">
+          <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            {title}
+          </h2>
+          {subtitle && (
+            <p className="text-muted-foreground mt-4 text-xl">{subtitle}</p>
+          )}
+        </div>
+
+        {showFilters && (
+          <div className="mb-8 flex flex-wrap justify-center gap-4">
+            <Button variant="outline" size="sm">
+              All Events
+            </Button>
+            <Button variant="outline" size="sm">
+              Upcoming
+            </Button>
+            <Button variant="outline" size="sm">
+              Past
+            </Button>
+          </div>
+        )}
+
+        <div
+          className={`grid gap-8 ${layout === "grid" ? getGridColumns() : "space-y-8"}`}
+        >
+          {events.map((event, index) => (
+            <Card
+              key={index}
+              className="overflow-hidden transition-shadow duration-300 hover:shadow-lg"
+            >
+              {event.image && event.image.media && event.image.media.url && (
+                <div className="aspect-video overflow-hidden">
+                  <img
+                    src={event.image.media.url}
+                    alt={event.image.alt || event.title}
+                    className="h-full w-full object-cover"
+                  />
+                </div>
+              )}
+
+              <CardHeader className="space-y-2">
+                <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                  <Calendar className="h-4 w-4" />
+                  <span>{event.date ? formatDate(event.date) : ""}</span>
+                  {event.time && (
+                    <>
+                      <Clock className="h-4 w-4" />
+                      <span>{formatTime(event.time)}</span>
+                    </>
+                  )}
+                </div>
+
+                <CardTitle className="text-2xl">{event.title}</CardTitle>
+
+                {event.location && (
+                  <div className="text-muted-foreground flex items-center gap-2 text-sm">
+                    <MapPin className="h-4 w-4" />
+                    <span>{event.location}</span>
+                  </div>
+                )}
+
+                {event.tags && event.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {event.tags.map((tag, tagIndex) => (
+                      <span
+                        key={tagIndex}
+                        className="bg-secondary text-secondary-foreground inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs"
+                      >
+                        <Tag className="h-3 w-3" />
+                        {tag.text}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </CardHeader>
+
+              <CardContent>
+                {event.description && (
+                  <CardDescription className="prose prose-sm max-w-none">
+                    {event.description}
+                  </CardDescription>
+                )}
+
+                {event.ctaLink && event.ctaLink.href && (
+                  <div className="mt-6">
+                    <Button asChild variant="outline">
+                      <a
+                        href={event.ctaLink.href}
+                        target={event.ctaLink.newTab ? "_blank" : "_self"}
+                        rel="noreferrer"
+                      >
+                        {event.ctaLink.label || "Learn More"}
+                      </a>
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/scripts/fetch-connect-forms.py
+++ b/scripts/fetch-connect-forms.py
@@ -1,0 +1,81 @@
+import requests
+from datetime import datetime
+
+# Strapi Configuration
+STRAPI_URL = "https://backend.apps.viswam.ai"
+API_TOKEN = "a6e7e374b93364e9bb2fe285c15f0b08c182390676091cc11986259228957a801f0e8ff3e40913c69334af21978c422682bc0f1875837a3dab9416646e08b767fce86525236b14516f2ecc91239346af099aa8fb3bc24d6a3600cf7ac8191984506fb220fac20b0ab98b9f4d1c288aa5c3a284c63b6a11d9862abce2ad01f5b4"
+
+HEADERS = {
+    "Authorization": f"Bearer {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+def fetch_connect_forms():
+    """Fetch all connect-form submissions from Strapi"""
+    url = f"{STRAPI_URL}/api/connect-forms?populate=*&sort[0]=createdAt:desc"
+    response = requests.get(url, headers=HEADERS)
+    
+    if response.status_code == 200:
+        return response.json().get("data", [])
+    else:
+        print(f"❌ Error {response.status_code}: {response.text}")
+        return []
+
+def display_forms(forms):
+    """Display forms in a nice format"""
+    if not forms:
+        print("📭 No connect-form submissions found.")
+        return
+    
+    print(f"\n{'='*80}")
+    print(f"📋 CONNECT-FORM SUBMISSIONS ({len(forms)} total)")
+    print(f"{'='*80}\n")
+    
+    for i, form in enumerate(forms, 1):
+        attrs = form.get("attributes", {})
+        doc = attrs.get("document", {})
+        
+        # Get file names if documents exist
+        file_names = []
+        if doc.get("data"):
+            if isinstance(doc["data"], list):
+                file_names = [f.get("name") for f in doc["data"] if f.get("name")]
+            elif isinstance(doc["data"], dict):
+                file_names = [doc["data"].get("name")]
+        
+        print(f"{'─'*80}")
+        print(f"📝 Submission #{i}")
+        print(f"{'─'*80}")
+        print(f"  👤 Name:          {attrs.get('name', 'N/A')}")
+        print(f"  📧 Email:         {attrs.get('email', 'N/A')}")
+        print(f"  📞 Phone:         {attrs.get('phone', 'N/A')}")
+        print(f"  🏢 Company:       {attrs.get('company', 'N/A')}")
+        print(f"  📂 Category:      {attrs.get('category', 'N/A')}")
+        print(f"  🔴 Priority:      {attrs.get('priority', 'N/A')}")
+        print(f"  ✅ Status:        {attrs.get('status', 'N/A')}")
+        print(f"  📅 Preferred Date:{attrs.get('preferredDate', 'N/A')}")
+        print(f"  📜 Terms Agreed:  {'✅' if attrs.get('agreeTerms') else '❌'}")
+        print(f"  🔒 Privacy Agreed:{'✅' if attrs.get('agreePrivacy') else '❌'}")
+        print(f"  🎯 Interests:     {', '.join(attrs.get('interests', []))}")
+        print(f"  📄 Documents:     {', '.join(file_names) if file_names else 'None'}")
+        print(f"")
+        print(f"  💬 Message:")
+        print(f"     {attrs.get('message', 'N/A')}")
+        print(f"")
+        print(f"  📝 Description:")
+        print(f"     {attrs.get('description', 'N/A')}")
+        print(f"")
+        print(f"  💭 Comments:")
+        print(f"     {attrs.get('comments', 'N/A')}")
+        print(f"")
+        print(f"  🆔 ID:            {form.get('id')}")
+        print(f"  🕐 Created:       {attrs.get('createdAt', 'N/A')}")
+        print(f"{'─'*80}\n")
+
+def main():
+    print("🔄 Fetching connect-form submissions...")
+    forms = fetch_connect_forms()
+    display_forms(forms)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fetch-events.py
+++ b/scripts/fetch-events.py
@@ -1,0 +1,85 @@
+import requests
+
+# Strapi Configuration
+STRAPI_URL = "https://backend.apps.viswam.ai"
+API_TOKEN = "a6e7e374b93364e9bb2fe285c15f0b08c182390676091cc11986259228957a801f0e8ff3e40913c69334af21978c422682bc0f1875837a3dab9416646e08b767fce86525236b14516f2ecc91239346af099aa8fb3bc24d6a3600cf7ac8191984506fb220fac20b0ab98b9f4d1c288aa5c3a284c63b6a11d9862abce2ad01f5b4"
+
+HEADERS = {
+    "Authorization": f"Bearer {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+def fetch_events():
+    """Fetch all events from Strapi"""
+    url = f"{STRAPI_URL}/api/events?populate=*&sort[0]=date:asc"
+    response = requests.get(url, headers=HEADERS)
+    
+    if response.status_code == 200:
+        return response.json().get("data", [])
+    else:
+        print(f"❌ Error {response.status_code}: {response.text}")
+        return []
+
+def display_events(events):
+    """Display events in a nice format"""
+    if not events:
+        print("📭 No events found.")
+        return
+    
+    print(f"\n{'='*80}")
+    print(f"📅 EVENTS ({len(events)} total)")
+    print(f"{'='*80}\n")
+    
+    for i, event in enumerate(events, 1):
+        attrs = event.get("attributes", {})
+        image = attrs.get("image", {})
+        image_url = None
+        
+        # Get image URL if exists
+        if image.get("data"):
+            img_data = image["data"]
+            if isinstance(img_data, dict):
+                image_url = img_data.get("url", "")
+        
+        tags = attrs.get("tags", {}).get("data", [])
+        tag_names = [t.get("attributes", {}).get("text") for t in tags if t.get("attributes")]
+        
+        sessions = attrs.get("roundtableSessions", [])
+        session_titles = [s.get("title") for s in sessions if s.get("title")]
+        
+        print(f"{'─'*80}")
+        print(f"🎫 Event #{i}")
+        print(f"{'─'*80}")
+        print(f"  📌 Title:            {attrs.get('title', 'N/A')}")
+        print(f"  🔗 Slug:             {attrs.get('slug', 'N/A')}")
+        print(f"  📝 Subtitle:         {attrs.get('subtitle', 'N/A')}")
+        print(f"  📅 Date:             {attrs.get('date', 'N/A')}")
+        print(f"  🕐 Time:             {attrs.get('time', 'N/A')}")
+        print(f"  📍 Location:         {attrs.get('location', 'N/A')}")
+        print(f"  🎭 Event Type:       {attrs.get('eventType', 'N/A')}")
+        print(f"  ⭐ Featured:         {'✅' if attrs.get('featured') else '❌'}")
+        print(f"  👥 Capacity:         {attrs.get('capacity', 'N/A')}")
+        print(f"  💰 Price:            ${attrs.get('price', 0)}")
+        print(f"  🎟️ Registration:     {'Required' if attrs.get('registrationRequired') else 'Not Required'}")
+        print(f"  🔗 Reg Link:         {attrs.get('registrationLink', 'N/A')}")
+        print(f"  🏢 Organizers:       {attrs.get('organizers', 'N/A')}")
+        print(f"  🏷️ Tags:            {', '.join(filter(None, tag_names)) if tag_names else 'None'}")
+        print(f"  📋 Sessions:         {', '.join(session_titles) if session_titles else 'None'}")
+        print(f"  🎫 Participation:    {attrs.get('participationOptions', 'N/A')}")
+        print(f"  🖼️ Image URL:        {image_url if image_url else 'None'}")
+        print(f"")
+        print(f"  📄 Description:")
+        print(f"     {attrs.get('description', 'N/A')}")
+        print(f"")
+        print(f"  🆔 ID:               {event.get('id')}")
+        print(f"  📊 Published At:     {attrs.get('publishedAt', 'Draft')}")
+        print(f"  🕐 Created:          {attrs.get('createdAt', 'N/A')}")
+        print(f"{'─'*80}\n")
+
+def main():
+    print("🔄 Fetching events...")
+    events = fetch_events()
+    display_events(events)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/submit-connect-form.py
+++ b/scripts/submit-connect-form.py
@@ -1,0 +1,52 @@
+import requests
+
+# Strapi Configuration
+STRAPI_URL = "https://backend.apps.viswam.ai"
+API_TOKEN = "YOUR_API_TOKEN"  # Replace with your Strapi API Token
+
+HEADERS = {
+    "Authorization": f"Bearer {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+def create_connect_form(form_data):
+    """Create a connect-form entry in Strapi"""
+    url = f"{STRAPI_URL}/api/connect-forms"
+    response = requests.post(url, headers=HEADERS, json={"data": form_data})
+    return response.json()
+
+def main():
+    # ===== FILL YOUR DATA HERE =====
+    form_data = {
+        # Text inputs
+        "name": "Pavani Pothuganti",
+        "email": "pavani@viswam.ai",
+        "phone": "+91-9876543210",
+        "company": "Viswam AI",
+        
+        # Text areas
+        "message": "Interested in your services",
+        "description": "Project inquiry",
+        "comments": "Please contact me ASAP",
+        
+        # Select dropdown
+        "category": "sales",
+        
+        # Radio button (single choice)
+        "priority": "high",
+        
+        # Checkboxes (multiple choices)
+        "interests": ["web-development", "ai-ml", "consulting"],
+        "agreeTerms": True,
+        "agreePrivacy": True,
+        
+        # Date/time picker
+        "preferredDate": "2026-04-15T10:00:00.000Z"
+    }
+    
+    response = create_connect_form(form_data)
+    print("✅ Success!" if "data" in response else f"❌ Error: {response}")
+    print(response)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/submit-event.py
+++ b/scripts/submit-event.py
@@ -1,0 +1,59 @@
+import requests
+
+# Strapi Configuration
+STRAPI_URL = "https://backend.apps.viswam.ai"
+API_TOKEN = "a6e7e374b93364e9bb2fe285c15f0b08c182390676091cc11986259228957a801f0e8ff3e40913c69334af21978c422682bc0f1875837a3dab9416646e08b767fce86525236b14516f2ecc91239346af099aa8fb3bc24d6a3600cf7ac8191984506fb220fac20b0ab98b9f4d1c288aa5c3a284c63b6a11d9862abce2ad01f5b4"
+
+HEADERS = {
+    "Authorization": f"Bearer {API_TOKEN}",
+    "Content-Type": "application/json"
+}
+
+def create_event(event_data):
+    """Create an event entry in Strapi"""
+    url = f"{STRAPI_URL}/api/events"
+    response = requests.post(url, headers=HEADERS, json={"data": event_data})
+    return response.json()
+
+def main():
+    # ===== FILL YOUR EVENT DATA HERE =====
+    event_data = {
+        # Required fields
+        "title": "Tech Conference 2026",
+        "slug": "tech-conference-2026",
+        "date": "2026-05-15",
+        
+        # Optional fields
+        "subtitle": "Annual Technology & Innovation Summit",
+        "time": "09:00:00.000Z",
+        "location": "Hyderabad Convention Center",
+        "description": "Join us for the biggest tech conference of the year featuring AI, cloud, and blockchain.",
+        "organizers": "Viswam AI Team",
+        "eventType": "Conference",
+        "featured": True,
+        "capacity": 500,
+        "price": 99.99,
+        "registrationRequired": True,
+        "registrationLink": "https://example.com/register",
+        "participationOptions": "Online or In-person",
+        
+        # Tags (array of text)
+        "tags": [
+            {"text": "AI"},
+            {"text": "Technology"},
+            {"text": "Networking"}
+        ]
+        
+        # Roundtable sessions (if needed)
+        # "roundtableSessions": [
+        #     {"title": "AI in Healthcare", "time": "10:00"},
+        #     {"title": "Blockchain Future", "time": "14:00"}
+        # ]
+    }
+    
+    response = create_event(event_data)
+    print("✅ Event Created!" if "data" in response else f"❌ Error: {response}")
+    print(response)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Added `connect-form` collection type with all required fields:
  - Text inputs: name, email, phone, company
  - Text areas: message, description, comments
  - Select dropdowns: category
  - Radio buttons: priority
  - Checkboxes: interests, agreeTerms, agreePrivacy
  - Date/time picker: preferredDate
  - File uploads: document
- Created full CRUD routes, controllers, and services
- Added Python script for form submission via REST API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event management to the CMS with support for registration, capacity limits, pricing, and roundtable sessions.
  * Introduced a new "Connect Form" for capturing user submissions with customizable fields and categorization.
  * Added events section to page builder for displaying events with filtering, grid/list layout options, and responsive design.
  * Extended form system with specialized templates for events, internships, job applications, and general inquiries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->