### PR TITLE
feat: add Event collection type with CRUD API

### DIFF
--- a/apps/strapi/sample-event-data.json
+++ b/apps/strapi/sample-event-data.json
@@ -1,0 +1,33 @@
+{
+  "event": {
+    "title": "From Code to Creativity – A stakeholder consultation event on responsible AI development and governance in India",
+    "slug": "from-code-to-creativity-stakeholder-consultation-2026",
+    "subtitle": "Understanding Trust and Safety in AI",
+    "date": "2026-01-31",
+    "time": "09:30:00",
+    "location": "IIIT Hyderabad",
+    "description": "VISWAM.AI, SFLC.in, FOSS United, and The Linux Foundation are jointly organising this in-person stakeholder consultation event.\n\nThe event brings together policymakers, industry leaders, open-source practitioners, creators, and civil society to examine how trust, safety, and accountability can be embedded into AI systems from the stage of design and training. Two closed-door roundtable discussions will focus on critical governance questions shaping India's AI ecosystem.",
+    "organizers": "VISWAM.AI, SFLC.in, FOSS United, and The Linux Foundation",
+    "registrationRequired": true,
+    "registrationLink": "https://forms.example.com/register",
+    "eventType": "Consultation",
+    "featured": true,
+    "participationOptions": "Available both in-person at IIIT Hyderabad and online",
+    "roundtableSessions": [
+      {
+        "title": "Harnessing Open Source AI",
+        "description": "Examining the role of open-source AI in building transparent, accountable, and inclusive AI systems. Critically exploring what \"open\" means in the context of AI models, data, licensing, safety, and governance."
+      },
+      {
+        "title": "Balancing AI Innovation and Copyright",
+        "description": "Deliberating on the DPIIT Working Paper on Generative AI and Copyright, including the proposed hybrid licensing model and its implications for AI developers, creators, and India's AI ecosystem."
+      }
+    ],
+    "tags": [
+      { "text": "AI Governance" },
+      { "text": "Trust & Safety" },
+      { "text": "Open Source" },
+      { "text": "India" }
+    ]
+  }
+}

--- a/apps/strapi/src/api/event/content-types/event/schema.json
+++ b/apps/strapi/src/api/event/content-types/event/schema.json
@@ -1,0 +1,161 @@
+{
+  "kind": "collectionType",
+  "collectionName": "events",
+  "info": {
+    "singularName": "event",
+    "pluralName": "events",
+    "displayName": "Event",
+    "description": "Event management for your website"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "required": true
+    },
+    "slug": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "required": true,
+      "unique": true,
+      "regex": "^[a-z0-9/-]+$"
+    },
+    "subtitle": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "date": {
+      "type": "date",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "required": true
+    },
+    "time": {
+      "type": "time",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "location": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "description": {
+      "type": "richtext",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": ["images", "videos"],
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "organizers": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "registrationRequired": {
+      "type": "boolean",
+      "default": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "registrationLink": {
+      "type": "string",
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "ctaLink": {
+      "type": "component",
+      "repeatable": false,
+      "component": "utilities.link"
+    },
+    "tags": {
+      "type": "component",
+      "repeatable": true,
+      "component": "utilities.text"
+    },
+    "eventType": {
+      "type": "enumeration",
+      "enum": ["Conference", "Workshop", "Webinar", "Meetup", "Training", "Consultation", "Roundtable", "Other"]
+    },
+    "featured": {
+      "type": "boolean",
+      "default": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
+    },
+    "capacity": {
+      "type": "integer",
+      "min": 1
+    },
+    "price": {
+      "type": "decimal",
+      "min": 0
+    },
+    "roundtableSessions": {
+      "type": "component",
+      "repeatable": true,
+      "component": "elements.event-session"
+    },
+    "participationOptions": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}

--- a/apps/strapi/src/api/event/controllers/event.ts
+++ b/apps/strapi/src/api/event/controllers/event.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreController("api::event.event")

--- a/apps/strapi/src/api/event/routes/event.ts
+++ b/apps/strapi/src/api/event/routes/event.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreRouter("api::event.event")

--- a/apps/strapi/src/api/event/services/event.ts
+++ b/apps/strapi/src/api/event/services/event.ts
@@ -1,0 +1,3 @@
+import { factories } from "@strapi/strapi"
+
+export default factories.createCoreService("api::event.event")

--- a/apps/strapi/src/components/elements/event-session.json
+++ b/apps/strapi/src/components/elements/event-session.json
@@ -1,0 +1,32 @@
+{
+  "collectionName": "components_elements_event_sessions",
+  "info": {
+    "displayName": "Event Session",
+    "description": "Individual session/roundtable within an event"
+  },
+  "options": {},
+  "pluginOptions": {
+    "i18n": {
+      "localized": true
+    }
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    },
+    "description": {
+      "type": "text",
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added `Event` collection type with full event management
- Fields: title, slug, subtitle, date, time, location, description, image, organizers, registration, capacity, price, eventType, featured, roundtableSessions, etc.
- i18n support enabled
- Draft & Publish enabled
- Full CRUD routes, controllers, and services via Strapi factories
- Includes event components: event-session, event-item
- Dynamic section components for forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive Events management to the CMS, enabling creation and organization of events with support for event metadata (title, date, location), rich descriptions, registration configuration, event categorization, featured event designation, participation options, roundtable sessions, and event tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->