### PR TITLE
feat(strapi): add Microsoft SSO provider

### DIFF
--- a/apps/docs/docs/sso/microsoft-sso.md
+++ b/apps/docs/docs/sso/microsoft-sso.md
@@ -1,0 +1,176 @@
+# Strapi SSO with Microsoft Entra ID
+
+This page documents the Microsoft SSO setup for Strapi admin users in this project.
+
+Official Strapi documentation:
+
+- https://docs.strapi.io/cms/configurations/sso-providers/microsoft
+
+## Requirements
+
+- Strapi SSO for admin users is an Enterprise feature. A valid Strapi Enterprise license is required.
+- A Microsoft Entra ID tenant is required.
+- A Microsoft app registration must exist in the correct tenant.
+- Users who should sign in must have an email address or UPN in that tenant.
+- Valid callback URLs must be registered for every environment where SSO will be used.
+
+> [Tip]
+> For local development, it is important to set `STRAPI_LICENSE` and verify SSO displays correctly in the login screen.
+
+## Dependencies
+
+Libraries required by the provider - `passport-azure-ad-oauth2` and `jsonwebtoken`. By default, they are installed in Strapi project.
+
+`passport-azure-ad-oauth2` is the Entra OAuth2 strategy used by the provider. `jsonwebtoken` is used to decode the returned `id_token` and extract user claims.
+
+## Strapi-Side Configuration
+
+The important Strapi-side pieces are:
+
+- register the Microsoft provider in `admin.ts`
+- set the required environment variables
+- make the Microsoft logo available from Strapi `public/`
+- trust proxy headers in environments where HTTPS is terminated before Strapi
+
+Relevant `admin.ts` usage (in `config/admin.ts`):
+
+```ts
+import { microsoftSSOProvider } from "./auth-providers"
+
+export default ({ env }) => {
+  return {
+    auth: {
+      providers: [microsoftSSOProvider(env)].filter(Boolean),
+    },
+  }
+}
+```
+
+### Required environment variables
+
+```env
+STRAPI_LICENSE=
+APP_URL=
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+MICROSOFT_TENANT_ID=
+```
+
+Notes:
+
+- `STRAPI_LICENSE` is required for local testing because SSO is a Strapi Enterprise feature.
+- `APP_URL` must match the public URL of the current environment.
+- The callback URL sent to Microsoft is derived from `APP_URL`.
+- Without setting `MICROSOFT_XYZ` variables, the provider will not be included in Strapi admin auth providers, and the Microsoft SSO option will not appear on the login screen.
+
+### Static logo asset
+
+The example provider uses:
+
+```ts
+icon: "/microsoft-logo.svg"
+```
+
+That means `microsoft-logo.svg` must be placed in Strapi `public/` so it is served at `/microsoft-logo.svg`.
+
+### Reverse proxy configuration
+
+If Strapi runs behind Nginx, a load balancer, or another reverse proxy that terminates HTTPS, enable proxy trust in `config/server.ts` and `config/env/production/server.ts`. Typically with Azure App Service:
+
+```ts
+export default ({ env }) => ({
+  proxy: { koa: true }, // <-- this is the key setting to trust X-Forwarded-Proto
+  url: env("APP_URL"),
+})
+```
+
+Without this, Strapi may fail after successful SSO with:
+
+```text
+Cannot send secure cookie over unencrypted connection
+```
+
+This happens because the browser uses HTTPS, but Strapi only sees the internal HTTP hop unless it trusts `X-Forwarded-Proto`.
+
+Only enable proxy trust when Strapi is behind a trusted proxy and is not directly exposed to the public internet.
+
+## Microsoft / Entra-Side Configuration
+
+From the Microsoft side, the app registration owner needs to provide and configure:
+
+- the correct Entra tenant
+- a valid app registration in that tenant
+- a client ID
+- a client secret
+- the tenant ID
+- callback URLs for every environment
+
+The minimum requirements for the Microsoft app creator are:
+
+- The app must be registered in the same tenant where the users exist.
+- Users signing in must exist in that tenant and have a usable identity field such as email or UPN.
+- Redirect URIs must be configured for all environments where Strapi is used.
+- The client secret must be stored securely and exposed to Strapi as `MICROSOFT_CLIENT_SECRET`.
+- The app must be allowed to authenticate users from the intended tenant.
+
+Each environment needs its own callback URL in the app registration:
+
+```text
+http://localhost:1337/admin/connect/azure_ad_oauth2
+https://your-staging-host/admin/connect/azure_ad_oauth2
+https://your-production-host/admin/connect/azure_ad_oauth2
+```
+
+The exact production URL depends on the final public host name.
+
+- If a callback URL is missing or does not exactly match the URL generated from `APP_URL`, the Microsoft login flow will fail.
+- If the app is registered in the wrong tenant, a tenant-specific error such as `AADSTS700016` can occur.
+
+## How It Works Technically
+
+This integration follows the standard Node.js Passport pattern:
+
+```text
+Strapi admin auth
+  -> Passport-compatible provider setup
+  -> passport-azure-ad-oauth2
+  -> Microsoft Entra ID
+```
+
+At runtime, the flow is:
+
+1. The user clicks `Sign in with Microsoft` in the Strapi admin login screen.
+2. Strapi redirects the user to Microsoft Entra ID.
+3. Microsoft authenticates the user and validates that the account belongs to the configured tenant.
+4. Microsoft redirects the user back to Strapi's callback URL.
+5. Strapi receives an `id_token` and decodes it to extract user claims.
+6. Strapi resolves the admin user identity from the token and signs the user into Strapi.
+7. Strapi still applies its own admin roles and permissions after authentication.
+
+Important distinction:
+
+- Entra handles authentication.
+- Strapi handles authorization.
+
+That means Microsoft decides who can successfully authenticate, but Strapi still controls what that authenticated admin user is allowed to do inside the CMS.
+
+In the usual setup, Strapi roles are assigned in Strapi itself (after login). Entra roles are not automatically mapped unless additional custom synchronization is implemented.
+
+## Token and Claim Considerations
+
+The provider uses the returned `id_token` to derive the user's identity.
+
+The important practical detail is that Microsoft does not always include the `email` claim by default. In enterprise tenants, `upn` is usually the safest fallback.
+
+Typical claims used for identity resolution are:
+
+| Claim                | Meaning                                        |
+| -------------------- | ---------------------------------------------- |
+| `email`              | User email, not always present                 |
+| `upn`                | User Principal Name, usually the best fallback |
+| `preferred_username` | Alternate login name                           |
+| `unique_name`        | Alternate username field                       |
+| `given_name`         | First name                                     |
+| `family_name`        | Last name                                      |
+
+This is why the provider falls back across multiple identity fields rather than relying only on `email`.

--- a/apps/strapi/.env.example
+++ b/apps/strapi/.env.example
@@ -37,6 +37,9 @@ APP_URL=http://localhost:1337
 # Enable or disable receiving populated relations in webhooks. Default: false
 # WEBHOOKS_POPULATE_RELATIONS=
 
+# The license key for Strapi.
+# STRAPI_LICENSE=
+
 # ----- Database -------
 
 # Full connection string for the database. It has higher priority than the other database connection options.
@@ -162,6 +165,12 @@ CLIENT_URL=http://localhost:3000
 STRAPI_PREVIEW_ENABLED=true
 # Shared secret for frontend and backend that enables draft mode
 STRAPI_PREVIEW_SECRET=your-secret-key
+
+# ------- SSO providers -------
+
+# MICROSOFT_CLIENT_ID=
+# MICROSOFT_CLIENT_SECRET=
+# MICROSOFT_TENANT_ID=
 
 # ------- OTHER -------
 

--- a/apps/strapi/README.md
+++ b/apps/strapi/README.md
@@ -464,6 +464,14 @@ Edit `config/cron-tasks.ts` to add cron jobs. Enable them by setting `CRON_ENABL
 
 A simple health check endpoint is available at `/api/health`, e.g. [http://localhost:1337/api/health](http://localhost:1337/api/health). This can be used for monitoring and uptime checks.
 
+### Admin SSO (Microsoft Entra ID)
+
+This template includes an optional Microsoft SSO provider for Strapi admin login. The provider is registered in [config/admin.ts](config/admin.ts) and implemented in [config/auth-providers.ts](config/auth-providers.ts) using `passport-azure-ad-oauth2`. It activates automatically when `MICROSOFT_CLIENT_ID`, `MICROSOFT_CLIENT_SECRET`, and `MICROSOFT_TENANT_ID` are set; otherwise the Microsoft button is hidden from the login screen.
+
+Strapi admin SSO is a Strapi Enterprise feature and requires a valid `STRAPI_LICENSE`. When Strapi runs behind a reverse proxy that terminates HTTPS, `proxy: { koa: true }` must be enabled in `config/server.ts` so secure cookies work after the OAuth redirect.
+
+Full setup (Entra app registration, callback URLs, claim handling, troubleshooting): [/docs/sso/microsoft-sso.md](../../apps/docs/docs/sso/microsoft-sso.md).
+
 ### Strapi Live Previews
 
 This starter supports Strapi's new feature: [Previews](https://docs.strapi.io/cms/features/preview). It works by embedding an iframe of the frontend application directly inside the editor.

--- a/apps/strapi/config/admin.ts
+++ b/apps/strapi/config/admin.ts
@@ -1,5 +1,6 @@
 import type { UID } from "@strapi/strapi"
 
+import { microsoftSSOProvider } from "./auth-providers"
 import type { StrapiPreviewConfig } from "../types/internals"
 
 export default ({ env }) => {
@@ -13,6 +14,7 @@ export default ({ env }) => {
   return {
     auth: {
       secret: env("ADMIN_JWT_SECRET"),
+      providers: [microsoftSSOProvider(env)].filter(Boolean),
     },
     apiToken: {
       salt: env("API_TOKEN_SALT"),

--- a/apps/strapi/config/auth-providers.ts
+++ b/apps/strapi/config/auth-providers.ts
@@ -1,0 +1,56 @@
+import jwt from "jsonwebtoken"
+import AzureAdOAuth2Strategy from "passport-azure-ad-oauth2"
+
+export function microsoftSSOProvider(
+  env: (key: string, defaultValue?: string) => string | undefined
+) {
+  const clientID = env("MICROSOFT_CLIENT_ID")
+  const clientSecret = env("MICROSOFT_CLIENT_SECRET")
+  const tenant = env("MICROSOFT_TENANT_ID")
+
+  if (!clientID || !clientSecret || !tenant) {
+    console.warn("Microsoft SSO provider is not configured", {
+      hasClientId: Boolean(clientID),
+      hasClientSecret: Boolean(clientSecret),
+      hasTenant: Boolean(tenant),
+    })
+
+    return null
+  }
+
+  return {
+    uid: "azure_ad_oauth2",
+    displayName: "Microsoft",
+    icon: "/microsoft-logo.svg",
+    createStrategy: (_strapi) => {
+      return new AzureAdOAuth2Strategy(
+        {
+          clientID,
+          clientSecret,
+          scope: ["user:email"],
+          tenant,
+          callbackURL: `${env("APP_URL")}/admin/connect/azure_ad_oauth2`,
+        },
+        (accessToken, refreshToken, params, profile, done) => {
+          const waadProfile = jwt.decode(params.id_token) as Record<
+            string,
+            string | undefined
+          >
+
+          const email =
+            waadProfile.email ??
+            waadProfile.upn ??
+            waadProfile.preferred_username ??
+            waadProfile.unique_name
+
+          done(null, {
+            email,
+            username: email,
+            firstname: waadProfile.given_name ?? "",
+            lastname: waadProfile.family_name ?? "",
+          })
+        }
+      )
+    },
+  }
+}

--- a/apps/strapi/config/env/production/server.ts
+++ b/apps/strapi/config/env/production/server.ts
@@ -1,7 +1,7 @@
 import cronTasks from "../../cron-tasks"
 
 export default ({ env }) => ({
-  proxy: true,
+  proxy: { koa: true },
   url: env("APP_URL"), // Sets the public URL of the application.
   app: {
     keys: env.array("APP_KEYS"),

--- a/apps/strapi/config/server.ts
+++ b/apps/strapi/config/server.ts
@@ -1,6 +1,7 @@
 import cronTasks from "./cron-tasks"
 
 export default ({ env }) => ({
+  proxy: { koa: true },
   host: env("HOST", "0.0.0.0"),
   port: env.int("PORT", 1337),
   url: env("APP_URL"),

--- a/apps/strapi/package.json
+++ b/apps/strapi/package.json
@@ -45,6 +45,7 @@
     "jsonwebtoken": "9.0.3",
     "lodash": "4.18.1",
     "nodemailer": "8.0.7",
+    "passport-azure-ad-oauth2": "0.0.4",
     "pg": "8.20.0",
     "qs": "6.15.1",
     "react": "^18.0.0",

--- a/apps/strapi/public/microsoft-logo.svg
+++ b/apps/strapi/public/microsoft-logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="24" viewBox="0 0 120 24">
+  <g transform="translate(14, 0)">
+    <rect x="1" y="1" width="10" height="10" fill="#f25022"/>
+    <rect x="12" y="1" width="10" height="10" fill="#7fba00"/>
+    <rect x="1" y="12" width="10" height="10" fill="#00a4ef"/>
+    <rect x="12" y="12" width="10" height="10" fill="#ffb900"/>
+    <text x="28" y="17" font-family="Segoe UI, Arial, sans-serif" font-size="14" fill="#5e5e5e">Microsoft</text>
+  </g>
+</svg>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       nodemailer:
         specifier: 8.0.7
         version: 8.0.7
+      passport-azure-ad-oauth2:
+        specifier: 0.0.4
+        version: 0.0.4
       pg:
         specifier: 8.20.0
         version: 8.20.0
@@ -8482,6 +8485,10 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  base64url@3.0.1:
+    resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
+    engines: {node: '>=6.0.0'}
+
   baseline-browser-mapping@2.10.17:
     resolution: {integrity: sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==}
     engines: {node: '>=6.0.0'}
@@ -13203,6 +13210,12 @@ packages:
   oauth-sign@0.9.0:
     resolution: {integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==}
 
+  oauth@0.10.2:
+    resolution: {integrity: sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==}
+
+  oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -13522,8 +13535,23 @@ packages:
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
+  passport-azure-ad-oauth2@0.0.4:
+    resolution: {integrity: sha512-yjwi0qXzGPIrR8yI5mBql2wO6tf/G5+HAFllkwwZ6f2EBCVvRv5z+6CwQeBvlrDbFh8RCXdj/IfB17r8LYDQQQ==}
+
   passport-local@1.0.0:
     resolution: {integrity: sha512-9wCE6qKznvf9mQYYbgJ3sVOHmCWoUNMVFoZzNoznmISbhnNNPhN9xfY3sLmScHMetEJeoY7CXwfhCe7argfQow==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth1@1.3.0:
+    resolution: {integrity: sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth2@1.8.0:
+    resolution: {integrity: sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==}
+    engines: {node: '>= 0.4.0'}
+
+  passport-oauth@1.0.0:
+    resolution: {integrity: sha512-4IZNVsZbN1dkBzmEbBqUxDG8oFOIK81jqdksE3HEb/vI3ib3FMjbiZZ6MTtooyYZzmKu0BfovjvT1pdGgIq+4Q==}
     engines: {node: '>= 0.4.0'}
 
   passport-strategy@1.0.0:
@@ -16275,6 +16303,9 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uid2@0.0.4:
+    resolution: {integrity: sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==}
 
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
@@ -19124,6 +19155,8 @@ snapshots:
       '@ckeditor/ckeditor5-widget': 47.6.1
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-list@47.6.1':
     dependencies:
@@ -19138,6 +19171,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-markdown-gfm@47.6.1':
     dependencies:
@@ -19175,6 +19210,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       '@ckeditor/ckeditor5-widget': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-mention@47.6.1':
     dependencies:
@@ -19194,6 +19231,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-page-break@47.6.1':
     dependencies:
@@ -19203,6 +19242,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       '@ckeditor/ckeditor5-widget': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-paragraph@47.6.1':
     dependencies:
@@ -19211,6 +19252,8 @@ snapshots:
       '@ckeditor/ckeditor5-icons': 47.6.1
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-paste-from-office@47.6.1':
     dependencies:
@@ -19241,6 +19284,8 @@ snapshots:
       '@ckeditor/ckeditor5-ui': 47.6.1
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-select-all@47.6.1':
     dependencies:
@@ -19287,6 +19332,8 @@ snapshots:
       '@ckeditor/ckeditor5-utils': 47.6.1
       ckeditor5: 47.6.1
       es-toolkit: 1.39.5
+    transitivePeerDependencies:
+      - supports-color
 
   '@ckeditor/ckeditor5-table@47.6.1':
     dependencies:
@@ -29743,6 +29790,8 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  base64url@3.0.1: {}
+
   baseline-browser-mapping@2.10.17: {}
 
   basic-ftp@5.1.0: {}
@@ -35406,6 +35455,10 @@ snapshots:
 
   oauth-sign@0.9.0: {}
 
+  oauth@0.10.2: {}
+
+  oauth@0.9.15: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -35758,9 +35811,32 @@ snapshots:
       no-case: 3.0.4
       tslib: 2.8.1
 
+  passport-azure-ad-oauth2@0.0.4:
+    dependencies:
+      passport-oauth: 1.0.0
+
   passport-local@1.0.0:
     dependencies:
       passport-strategy: 1.0.0
+
+  passport-oauth1@1.3.0:
+    dependencies:
+      oauth: 0.9.15
+      passport-strategy: 1.0.0
+      utils-merge: 1.0.1
+
+  passport-oauth2@1.8.0:
+    dependencies:
+      base64url: 3.0.1
+      oauth: 0.10.2
+      passport-strategy: 1.0.0
+      uid2: 0.0.4
+      utils-merge: 1.0.1
+
+  passport-oauth@1.0.0:
+    dependencies:
+      passport-oauth1: 1.3.0
+      passport-oauth2: 1.8.0
 
   passport-strategy@1.0.0: {}
 
@@ -39164,6 +39240,8 @@ snapshots:
 
   uglify-js@3.19.3:
     optional: true
+
+  uid2@0.0.4: {}
 
   uint8array-extras@1.5.0: {}
 


### PR DESCRIPTION
### Task Link
closes #304 

### Description
Adds Microsoft (Azure AD) SSO as a Strapi admin auth provider. A new `auth-providers.ts` factory registers a `passport-azure-ad-oauth2` strategy in `config/admin.ts`, but only when all three Microsoft env vars are set — otherwise it logs a warning and is filtered out. The `id_token` is decoded to populate email/username/first/last name.

Also switches `proxy` to `{ koa: true }` in base and production server configs, required by newer Strapi for correct callback URL resolution behind a reverse proxy. Setup docs added at `apps/docs/docs/sso/microsoft-sso.md`.

#### TL;DR
Enables Microsoft SSO login for the Strapi admin via Azure AD OAuth2.

### Screenshots/Videos
N/A

### New environmental variables
- `MICROSOFT_CLIENT_ID` — Azure AD application (client) ID
- `MICROSOFT_CLIENT_SECRET` — Azure AD client secret
- `MICROSOFT_TENANT_ID` — Azure AD tenant ID
- `STRAPI_LICENSE` — Strapi license key

Apply the `requires-env-vars` label.

### Checklist - author

- [x] **Assignee** is set (the active developer of this PR).
- [ ] **Reviewers** are set (team members who will review the code).
- [x] **PR is linked** I have linked the PR to an issue in Jira.
- [x] **Description** I have described the changes proposed in the PR clearly and concisely (more important than what is why).
- [x] **Screenshots/Videos** I have added screenshots/videos or they were not needed.
- [x] **Environmental variables** are listed or they were not needed.
- [ ] **Unit/Integration tests** are added for all utilities and business important logic
- [x] **Labels** I have added labels to the PR.
  - Use `requires-env-vars` when PR requires environmental variables
  - Use `ready-for-review` when PR is ready to be looked at
  - Use `ready-to-merge` when PR has a passing review
  - Use `needs-revisions` when PR has comments that block merge
  - Use `do-not-review` when PR is daft only and you don't want to get a review
- [ ] [OPTIONAL] Conversation/documentation is started in places where the code is not self-explanatory

#### Before merging

- [ ] **PR is approved**
- [ ] **All conversations are resolved**
- [ ] Pipelines are not failing

### Checklist - reviewer

- [ ] I **understand** all proposed changes.
- [ ] Necessary **after deploy steps** are handled by someone (adding new env var, syncing config, running migration...)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Microsoft Entra ID SSO now available for Strapi admin authentication, automatically enabled when configured with appropriate credentials.

* **Documentation**
  * Added comprehensive setup guide for Microsoft Entra ID SSO covering prerequisites, Strapi and Microsoft configuration steps, and login flow details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/notum-cz/strapi-next-monorepo-starter/pull/305)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->