### PR TITLE
chore: upgrade pnpm to v11

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -5,7 +5,7 @@ inputs:
   pnpm-version:
     description: 'pnpm version to install'
     required: false
-    default: '11.0.0'
+    default: '11.1.1'
 
 runs:
   using: 'composite'

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -5,7 +5,7 @@ inputs:
   pnpm-version:
     description: 'pnpm version to install'
     required: false
-    default: '10.33.3'
+    default: '11.0.0'
 
 runs:
   using: 'composite'

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ This is a ready-to-go starter template for Strapi projects. It combines the powe
    # switch to correct nodejs version (v24)
    nvm use
 
-   # optionally, switch to pnpm v11.0.0
-   (corepack prepare pnpm@11.0.0 --activate)
+   # optionally, switch to pnpm v11.1.1
+   (corepack prepare pnpm@11.1.1 --activate)
 
    # install deps for apps and packages that are part of this monorepo
    pnpm install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is a ready-to-go starter template for Strapi projects. It combines the powe
 
 - Docker
 - node 24
-- pnpm 10
+- pnpm 11
 - [nvm](https://github.com/nvm-sh/nvm) (optional, recommended)
 
 ### Run dev (in 4 steps)
@@ -48,8 +48,8 @@ This is a ready-to-go starter template for Strapi projects. It combines the powe
    # switch to correct nodejs version (v24)
    nvm use
 
-   # optionally, switch to pnpm v10.33.3
-   (corepack prepare pnpm@10.33.3 --activate)
+   # optionally, switch to pnpm v11.0.0
+   (corepack prepare pnpm@11.0.0 --activate)
 
    # install deps for apps and packages that are part of this monorepo
    pnpm install

--- a/apps/strapi/Dockerfile
+++ b/apps/strapi/Dockerfile
@@ -16,7 +16,7 @@ RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev l
 # Install pnpm globally
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@11.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}

--- a/apps/strapi/Dockerfile
+++ b/apps/strapi/Dockerfile
@@ -15,8 +15,8 @@ RUN apk update && apk add --no-cache build-base gcc autoconf automake zlib-dev l
 
 # Install pnpm globally
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.33.3 --activate
+ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@11.0.0 --activate
 
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
@@ -70,7 +70,7 @@ COPY turbo.json turbo.json
 RUN turbo run build
 
 # Remove devDependencies after build to reduce image size
-RUN pnpm prune --prod
+# RUN pnpm prune --prod
 
 # ---
 FROM node:24-alpine AS runner

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -16,7 +16,7 @@ FROM node:24-slim AS base
 # Install pnpm globally
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@11.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@11.1.1 --activate
 
 # Set working directory
 WORKDIR /app

--- a/apps/ui/Dockerfile
+++ b/apps/ui/Dockerfile
@@ -15,8 +15,8 @@ FROM node:24-slim AS base
 
 # Install pnpm globally
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@10.33.3 --activate
+ENV PATH="$PNPM_HOME/bin:$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@11.0.0 --activate
 
 # Set working directory
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -65,72 +65,8 @@
     "tslib": "2.8.1",
     "turbo": "2.7.6"
   },
-  "packageManager": "pnpm@10.33.3",
+  "packageManager": "pnpm@11.0.0",
   "engines": {
     "node": "^24.0.0"
-  },
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "eslint": "^9.39.0",
-        "react": ">=18 <20",
-        "react-dom": ">=18 <20",
-        "styled-components": ">=6.0.0 <7",
-        "typescript": ">=5.4.0 <6",
-        "zod": ">=3.25.67 <5"
-      }
-    },
-    "overrides": {
-      "@types/react": "19.2.14",
-      "@types/react-dom": "19.2.3"
-    },
-    "packageExtensions": {
-      "@hookform/resolvers": {
-        "peerDependencies": {
-          "zod": "*"
-        }
-      },
-      "@uiw/codemirror-extensions-basic-setup": {
-        "peerDependenciesMeta": {
-          "@codemirror/autocomplete": {
-            "optional": true
-          },
-          "@codemirror/language": {
-            "optional": true
-          },
-          "@codemirror/lint": {
-            "optional": true
-          },
-          "@codemirror/search": {
-            "optional": true
-          },
-          "@codemirror/state": {
-            "optional": true
-          },
-          "@codemirror/view": {
-            "optional": true
-          }
-        }
-      },
-      "@uiw/react-codemirror": {
-        "peerDependenciesMeta": {
-          "@babel/runtime": {
-            "optional": true
-          },
-          "@codemirror/state": {
-            "optional": true
-          },
-          "@codemirror/theme-one-dark": {
-            "optional": true
-          },
-          "@codemirror/view": {
-            "optional": true
-          },
-          "codemirror": {
-            "optional": true
-          }
-        }
-      }
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tslib": "2.8.1",
     "turbo": "2.7.6"
   },
-  "packageManager": "pnpm@11.0.0",
+  "packageManager": "pnpm@11.1.1",
   "engines": {
     "node": "^24.0.0"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,57 @@
-packages: ["packages/*", "apps/*", "qa/**"]
+packages: [ "packages/*", "apps/*", "qa/**" ]
+allowBuilds:
+  "@parcel/watcher": true
+  "@sentry/cli": true
+  "@swc/core": true
+  core-js: true
+  core-js-pure: true
+  esbuild: true
+  lefthook: true
+  sharp: true
+  unrs-resolver: true
+
+minimumReleaseAge: 5760
+
+overrides:
+  "@types/react": 19.2.14
+  "@types/react-dom": 19.2.3
+
+packageExtensions:
+  "@hookform/resolvers":
+    peerDependencies:
+      zod: "*"
+  "@uiw/codemirror-extensions-basic-setup":
+    peerDependenciesMeta:
+      "@codemirror/autocomplete":
+        optional: true
+      "@codemirror/language":
+        optional: true
+      "@codemirror/lint":
+        optional: true
+      "@codemirror/search":
+        optional: true
+      "@codemirror/state":
+        optional: true
+      "@codemirror/view":
+        optional: true
+  "@uiw/react-codemirror":
+    peerDependenciesMeta:
+      "@babel/runtime":
+        optional: true
+      "@codemirror/state":
+        optional: true
+      "@codemirror/theme-one-dark":
+        optional: true
+      "@codemirror/view":
+        optional: true
+      codemirror:
+        optional: true
+
+peerDependencyRules:
+  allowedVersions:
+    eslint: ^9.39.0
+    react: ">=18 <20"
+    react-dom: ">=18 <20"
+    styled-components: ">=6.0.0 <7"
+    typescript: ">=5.4.0 <6"
+    zod: ">=3.25.67 <5"


### PR DESCRIPTION
closes #312 

Moved pnpm-specific config from package.json into pnpm-workspace.yaml, pinned packageManager and CI/Docker setup to pnpm@11.0.0, updated README setup instructions, and added pnpm 11 supply-chain/build-script policy config with a 4-day minimumReleaseAge plus explicit allowed dependency builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded pnpm package manager to the latest version across all project configurations, build systems, and deployment pipelines
  * Updated CI/CD actions and documentation to align with the new package manager version
  * Implemented enhanced workspace-level dependency management policies for improved stability and consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/notum-cz/strapi-next-monorepo-starter/pull/313)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->