### PR TITLE
Update documentation links to new app structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,14 +36,14 @@ This updates `@repo/strapi-types`. Forgetting causes silent type mismatches betw
 
 ## Documentation
 
-- [Commands Reference](docs/commands.md) — All pnpm commands
-- [Architecture](docs/architecture.md) — System design and patterns
-- [Page Builder](docs/page-builder.md) — Component registry and rendering
-- [Strapi API Client](docs/strapi-api-client.md) — Fetching content from Strapi
-- [Pages Hierarchy](docs/pages-hierarchy.md) — URL structure and redirects
-- [Authentication](docs/authentication.md) — Better Auth + Strapi JWT integration
-- [Strapi Schemas](docs/strapi-schemas.md) — Schema attributes, localization, lifecycle hooks
-- [Strapi Types](docs/strapi-types-usage.md) — Type utilities and usage patterns
+- [Commands Reference](apps/docs/docs/commands.md) — All pnpm commands
+- [Architecture](apps/docs/docs/architecture.md) — System design and patterns
+- [Page Builder](apps/docs/docs/page-builder.md) — Component registry and rendering
+- [Strapi API Client](apps/docs/docs/strapi-api-client.md) — Fetching content from Strapi
+- [Pages Hierarchy](apps/docs/docs/pages-hierarchy.md) — URL structure and redirects
+- [Authentication](apps/docs/docs/authentication.md) — Better Auth + Strapi JWT integration
+- [Strapi Schemas](apps/docs/docs/strapi-schemas.md) — Schema attributes, localization, lifecycle hooks
+- [Strapi Types](apps/docs/docs/strapi-types-usage.md) — Type utilities and usage patterns
 
 ## Commits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ pnpm lint             # ESLint all packages
 pnpm typecheck        # Typecheck (run from apps/ui)
 ```
 
-See [docs/commands.md](docs/commands.md) for full command reference.
+See [apps/docs/docs/commands.md](apps/docs/docs/commands.md) for full command reference.
 
 ## Type Generation (Critical)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to the docs’ new location.
  * Adjusted listed guides so commands, architecture, page builder, Strapi API client, pages hierarchy, authentication, Strapi schemas, and Strapi types all reference the relocated guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->