### PR TITLE
feat: handle Strapi-defined redirects in the Next.js app

### DIFF
--- a/apps/docs/docs/getting-started/features.md
+++ b/apps/docs/docs/getting-started/features.md
@@ -36,7 +36,7 @@ Shared code lives in [`packages/*`](../reference/packages/overview.md).
 - **[Caching defaults](../ui/caching.md)** — Strapi responses cache, Next.js page cache, ISR, and static export tradeoffs are documented.
 - **[Cache revalidation](../reference/cache-revalidation.md)** — Strapi publish/update/delete events can invalidate affected Next.js paths and shared data tags.
 - **[CDN cache purge](../reference/integrations/cdn.md)** — optional operator-triggered CDN eviction is available for urgent cache updates.
-- **[Next proxies](../ui/next-proxies.md)** — controlled proxy middleware handles locale redirects, HTTPS redirects, basic auth, and auth guards.
+- **[Next proxies](../ui/next-proxies.md)** — controlled proxy middleware handles locale redirects, HTTPS redirects, Strapi-defined redirects, basic auth, and auth guards.
 - **[SEO helpers](../ui/seo.md)** — metadata, sitemap, robots, canonical URLs, and structured data are generated from content.
 - **[Image handling](../ui/images.md)** — Strapi media helpers and optional imgproxy support are included.
 - **[Environment variables](../ui/environment-variables.md)** — runtime config, CSR env injection, public variables, and debug flags are documented.
@@ -48,6 +48,7 @@ Shared code lives in [`packages/*`](../reference/packages/overview.md).
 - **[Local setup](../strapi/installation.md)** — PostgreSQL runs through Docker for development.
 - **[Schema conventions](../strapi/strapi-schemas.md)** — content types, components, relations, lifecycle hooks, and document middlewares are documented.
 - **[Generated Strapi types](../reference/packages/strapi-types.md)** — schema-generated types are shared with the UI.
+- **[CMS redirects](../strapi/cms-redirects.md)** — editors manage `source` → `destination` redirects as content; the UI proxy applies them, and page moves create them automatically.
 - **Rich text editors** — [CKEditor](../strapi/plugins/ckeditor.md) and [Tiptap](../strapi/plugins/tiptap-editor.md) editor integrations are documented.
 - **[Upload providers](../strapi/plugins/upload-providers.md)** — local storage, Azure Blob Storage, and AWS S3 are supported.
 - **[Email providers](../strapi/plugins/email-providers.md)** — Mailgun production email and Mailtrap development email are wired through Strapi provider config.
@@ -74,15 +75,3 @@ Shared code lives in [`packages/*`](../reference/packages/overview.md).
 - **[Deployment](../reference/deployment/overview.md)** — GitHub Actions, Heroku, Vercel, and Docker deployment notes are documented.
 - **[Design system](../design-system/overview.md)** — shared tokens, typography, rich text styling, and CMS component design rules are documented.
 - **Integrations** — [Sentry](../reference/integrations/sentry.md), [reCAPTCHA](../reference/integrations/recaptcha.md), and [CDN / Azure Front Door](../reference/integrations/cdn.md) setup have dedicated reference pages.
-
-## Related Documentation
-
-- [Page Builder](../page-builder/introduction.md)
-- [UI Project Structure](../ui/project-structure.md)
-- [Strapi Plugins](../strapi/plugins/overview.md)
-- [Internationalization](../reference/internationalization.md)
-- [Testing](../reference/testing/overview.md)
-- [Packages](../reference/packages/overview.md)
-- [Deployment](../reference/deployment/overview.md)
-- [Cache Revalidation](../reference/cache-revalidation.md)
-- [CDN](../reference/integrations/cdn.md)

--- a/apps/docs/docs/page-builder/pages-hierarchy.md
+++ b/apps/docs/docs/page-builder/pages-hierarchy.md
@@ -30,6 +30,8 @@ Because the `fullPath` is generated automatically, it should never be edited man
 
 When the `fullPath` of a page is changed (because its `slug` or `parent` was changed), a redirect from the old `fullPath` to the new `fullPath` is automatically created. This is done using internal jobs (see below) and requires manual triggering of the jobs in the admin panel. Any other change (e.g. in `children` relation) doesn't affect this process.
 
+These auto-created entries are ordinary records in the **Redirect** collection. See [CMS Redirects](../strapi/cms-redirects) for how redirects are stored and served on the frontend, and how to author one manually.
+
 ### How it works
 
 1. Every time the published page changes the `slug` or `parent` relation field a new internal job (`api::internal-job.internal-job`) is created to regenerate the `fullPath` field. It has `jobType` set to `RECALCULATE_FULLPATH` and `state` set to `pending` (see "Internal Jobs" content type in admin panel).
@@ -102,3 +104,4 @@ Do one change at a time (e.g. change slug of one page, trigger jobs, verify resu
 ## Related Documentation
 
 - [Page Builder](./introduction.md) — Page Builder specific documentation
+- [CMS Redirects](../strapi/cms-redirects) — how the redirects created here are stored and served on the frontend

--- a/apps/docs/docs/reference/deployment/heroku.md
+++ b/apps/docs/docs/reference/deployment/heroku.md
@@ -123,7 +123,7 @@ fi
 ```
 
 :::warning Uploaded media
-Heroku dyno filesystems are ephemeral. Use S3, Azure Blob Storage, or another external upload provider for Strapi media. Uploaded files stored on the dyno can disappear after restarts, rebuilds, or dyno moves.
+Heroku dyno filesystems are ephemeral. Use [S3](../../strapi/plugins/upload-providers#aws-s3), [Azure Blob Storage](../../strapi/plugins/upload-providers#azure-blob-storage), or [another external upload provider](../../strapi/plugins/upload-providers) for Strapi media. Uploaded files stored on the dyno can disappear after restarts, rebuilds, or dyno moves.
 :::
 
 The repository currently includes `apps/strapi/Procfile`:

--- a/apps/docs/docs/strapi/cms-redirects.md
+++ b/apps/docs/docs/strapi/cms-redirects.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 5
+---
+
+# CMS Redirects
+
+Editors manage URL redirects as content, without code or a redeploy. Redirects live in the **Redirect** collection (`api::redirect.redirect`) and are applied on the frontend by the Next.js [redirects proxy](../ui/next-proxies#redirects).
+
+## The Redirect collection
+
+Each redirect is a published entry with two fields:
+
+| Field         | Description                                                               |
+| ------------- | ------------------------------------------------------------------------- |
+| `source`      | The incoming path to match, including the locale prefix (e.g. `/en/old`). |
+| `destination` | Where to send the visitor — a path on the same site (e.g. `/en/new`).     |
+
+The collection uses Draft & Publish: only **published** redirects are served. Unpublish or delete an entry to stop redirecting.
+
+:::tip Redirects are locale-aware
+Both `source` and `destination` carry a locale prefix, so each language variant has its own redirect. `/en/old → /en/new` and `/cs/stara → /cs/nova` are separate entries — a redirect for one locale does not affect another. The same applies to auto-created redirects: changing a page's slug in one locale only produces redirects for that locale.
+:::
+
+:::info Always temporary (307)
+There is no permanent/301 option by design. The frontend always issues a `307` temporary redirect so an editor can later fix or remove an entry without clients staying pinned to a stale destination. See [Redirects → Temporary by design](../ui/next-proxies#redirects) for the full reasoning.
+:::
+
+## How they are applied
+
+The Next.js [redirects proxy](../ui/next-proxies#redirects) matches each incoming request against the published redirect list and issues the redirect before the page renders. Key behaviors handled there:
+
+- Same-origin destinations only; the visitor's query string is preserved.
+- Default-locale URLs match with or without the locale prefix.
+- Editor typos in `source` (extra spaces, missing or trailing slash) are matched forgivingly.
+- The list is cached in-process, so a newly published or edited redirect takes effect within a short TTL (about 2 minutes per running instance) rather than instantly.
+
+## Manually authored redirects
+
+To add a redirect by hand:
+
+1. Create a **Redirect** entry with the `source` path (locale-prefixed) and the `destination`.
+2. **Publish** it.
+3. The change goes live on the frontend within the proxy cache TTL.
+
+## Automatically created redirects
+
+When a page's `slug` or `parent` changes, its `fullPath` (and its children's) changes too, so the old URLs must redirect to the new ones. The page hierarchy flow creates these `api::redirect.redirect` entries for you, locale-aware, via internal jobs. See [Pages Hierarchy](../page-builder/pages-hierarchy#full-path-generation-and-redirects) for the slug/parent change workflow and how to trigger it.
+
+## Cache revalidation
+
+Publishing a redirect path-revalidates its `source` in the Next.js cache, so a page previously cached at that URL is invalidated and the redirect can take over. See [Cache Revalidation](../reference/cache-revalidation) for the full Strapi → UI invalidation flow.

--- a/apps/docs/docs/strapi/cron-jobs.md
+++ b/apps/docs/docs/strapi/cron-jobs.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Cron Jobs

--- a/apps/docs/docs/strapi/docker-build.md
+++ b/apps/docs/docs/strapi/docker-build.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Docker Build

--- a/apps/docs/docs/strapi/strapi-preview.md
+++ b/apps/docs/docs/strapi/strapi-preview.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Strapi Preview

--- a/apps/docs/docs/ui/next-proxies.md
+++ b/apps/docs/docs/ui/next-proxies.md
@@ -26,8 +26,9 @@ Each proxy handles one concern and can either return a `NextResponse` to stop th
 | ----- | --------------- | ------------------- | -------------------------------------------------------------------------------- |
 | 1     | Basic Auth      | `basicAuth.ts`      | Enables HTTP Basic Auth for the whole app when `BASIC_AUTH_ENABLED=true`.        |
 | 2     | HTTPS Redirect  | `httpsRedirect.ts`  | Redirects non-HTTPS requests to HTTPS outside local development.                 |
-| 3     | Auth Guard      | `authGuard.ts`      | Protects pages listed in `authPages`; anonymous users are redirected to sign-in. |
-| 4     | Dynamic Rewrite | `dynamicRewrite.ts` | Rewrites requests with search params to the `/dynamic/` route for SSR.           |
+| 3     | Redirects       | `redirects.ts`      | Issues Strapi-defined source → destination redirects before the page renders.    |
+| 4     | Auth Guard      | `authGuard.ts`      | Protects pages listed in `authPages`; anonymous users are redirected to sign-in. |
+| 5     | Dynamic Rewrite | `dynamicRewrite.ts` | Rewrites requests with search params to the `/dynamic/` route for SSR.           |
 
 If none of these proxies handles the request, `next-intl` middleware handles locale routing.
 
@@ -52,6 +53,51 @@ Use this for environments that should not be publicly accessible.
 `httpsRedirect` redirects non-HTTPS requests to HTTPS outside local development. It checks `x-forwarded-proto`, which is commonly set by platforms and reverse proxies such as Heroku.
 
 Localhost and development mode are skipped.
+
+## Redirects
+
+`redirectsProxy` (`redirects.ts`) applies redirects authored in the Strapi **Redirect** collection (`source` → `destination`). It matches the incoming path against the published redirect list and issues the redirect before the page renders, so old URLs are honored without any per-page code.
+
+The starter resolves these Strapi-defined redirects **in-app**, inside Next.js middleware. That is the right default for most sites, but for a larger website fronted by a programmable CDN it is not the best solution — see [Alternative: redirect at the CDN / edge](#alternative-redirect-at-the-cdn--edge).
+
+How it works:
+
+- It acts only on real navigations (`GET`/`HEAD`) and ignores Next.js link prefetches, so background prefetching never triggers a redirect lookup.
+- The published redirect list is kept in memory for 2 minutes instead of being fetched from Strapi on every request. While that cache is fresh, lookups are instant; once it expires, the proxy keeps serving the last known list and refreshes in the background, so visitors never wait on Strapi. The one exception: if an expired cache has _no_ match for the requested path, the proxy refreshes and waits — the path might be a brand-new redirect that a fronting CDN has already started routing here, and serving a miss would let the CDN cache the wrong response.
+- Because of that cache, a newly published redirect goes live within ~2 minutes (per running instance). Publishing in Strapi cannot clear this cache instantly — the proxy runs separately from the rest of the app — so the cache lifetime is the activation window. Lower `REDIRECTS_CACHE_TTL_MS` (`apps/ui/src/lib/redirects.ts`) for faster activation.
+
+:::info Why a TTL instead of Strapi-triggered revalidation
+The proxy is Next.js **middleware**, which runs in its own runtime — separate from the **server runtime** that renders pages and route handlers — and the redirect list lives as a plain in-memory value inside it. Next's on-demand revalidation (`revalidateTag` / `revalidatePath`, what the Strapi publish pipeline calls) only invalidates the server runtime's Data Cache and rendered routes. There is no API to reach into middleware memory, and middleware cannot subscribe to those revalidation events — so a publish refreshes pages but cannot clear this cache. A time-based TTL is the only invalidation the middleware has, and each running instance holds its own copy (hence "per instance").
+:::
+
+- Editor-entered `source` values are matched forgivingly: extra spaces, a missing leading slash, or a trailing slash are ignored, so small typos don't create dead redirects.
+- Default-locale URLs match with or without the locale prefix, and the locale prefix is stripped from internal destinations so the visitor isn't redirected twice.
+- Only same-origin destinations are followed; external URLs are ignored. The visitor's query string carries over unless the destination defines its own.
+- If the lookup fails (for example, Strapi is down), the request simply renders normally — redirects never block the site.
+
+:::info Temporary by design
+CMS-managed redirects always respond with `307`. The Redirect collection has no permanent/301 option: a `308`/`301` is sticky in browser and crawler caches and cannot be purged once an editor fixes or removes the redirect, so a method-preserving temporary redirect is the only safe default for editor-managed content.
+:::
+
+### Alternative: redirect at the CDN / edge
+
+This proxy resolves redirects inside the app runtime. A different approach is to push the redirect list to the **CDN or edge layer** and decide there — before the request ever reaches the app — using a small key-value lookup. Services that support this include Cloudflare Workers / Bulk Redirects, Vercel Edge Middleware, AWS CloudFront Functions or Lambda@Edge, Fastly Compute, Akamai EdgeWorkers, and Azure Front Door Rules.
+
+It is an architectural fork worth deciding **early**, because it changes where redirect data lives and how it is deployed.
+
+**Pros**
+
+- Lowest latency: the redirect is issued at the network edge, closest to the visitor, with no round trip to the origin.
+- Fully offloads the origin — redirected requests never spend app runtime or hit Strapi.
+- Decides before any cache or render, so there is no stale-page-at-the-source-URL concern.
+
+**Cons**
+
+- Requires a sync pipeline to copy redirects from Strapi into the edge store (KV namespace, ruleset, or config push) on every publish — extra infrastructure and a new failure mode.
+- Provider-specific configuration and lock-in; harder to reproduce and test in local development.
+- Activation still has a delay, now governed by the edge deploy / KV propagation instead of a cache TTL.
+
+The in-app proxy is the portable default: it works on any Node host with no extra infrastructure and keeps redirect logic beside the app. Prefer the edge approach when redirect volume or traffic makes origin offload worthwhile and you already operate a programmable CDN.
 
 ## Auth Guard
 

--- a/apps/strapi/config/sync/admin-role.strapi-super-admin.json
+++ b/apps/strapi/config/sync/admin-role.strapi-super-admin.json
@@ -481,7 +481,6 @@
         "fields": [
           "source",
           "destination",
-          "permanent",
           "page"
         ]
       },
@@ -515,7 +514,6 @@
         "fields": [
           "source",
           "destination",
-          "permanent",
           "page"
         ]
       },
@@ -531,7 +529,6 @@
         "fields": [
           "source",
           "destination",
-          "permanent",
           "page"
         ]
       },

--- a/apps/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##redirect.redirect.json
+++ b/apps/strapi/config/sync/core-store.plugin_content_manager_configuration_content_types##api##redirect.redirect.json
@@ -47,20 +47,6 @@
           "sortable": true
         }
       },
-      "permanent": {
-        "edit": {
-          "label": "permanent",
-          "description": "",
-          "placeholder": "",
-          "visible": true,
-          "editable": true
-        },
-        "list": {
-          "label": "permanent",
-          "searchable": true,
-          "sortable": true
-        }
-      },
       "page": {
         "edit": {
           "label": "page",
@@ -149,10 +135,6 @@
         ],
         [
           {
-            "name": "permanent",
-            "size": 4
-          },
-          {
             "name": "page",
             "size": 6
           }
@@ -162,7 +144,6 @@
         "id",
         "source",
         "destination",
-        "permanent",
         "createdAt"
       ]
     },

--- a/apps/strapi/src/api/redirect/content-types/redirect/schema.json
+++ b/apps/strapi/src/api/redirect/content-types/redirect/schema.json
@@ -17,10 +17,6 @@
     "destination": {
       "type": "string",
       "required": true
-    },
-    "permanent": {
-      "type": "boolean",
-      "default": false
     }
   }
 }

--- a/apps/strapi/src/utils/hierarchy/index.ts
+++ b/apps/strapi/src/utils/hierarchy/index.ts
@@ -224,7 +224,6 @@ export const processCreateRedirectJob = async (
     data: {
       source: payload.oldPath,
       destination: payload.newPath,
-      permanent: true,
     },
     status: "published",
   })

--- a/apps/strapi/types/generated/contentTypes.d.ts
+++ b/apps/strapi/types/generated/contentTypes.d.ts
@@ -678,7 +678,6 @@ export interface ApiRedirectRedirect extends Struct.CollectionTypeSchema {
       "api::redirect.redirect"
     > &
       Schema.Attribute.Private
-    permanent: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>
     publishedAt: Schema.Attribute.DateTime
     source: Schema.Attribute.String & Schema.Attribute.Required
     updatedAt: Schema.Attribute.DateTime

--- a/apps/ui/src/lib/proxies/redirects.test.ts
+++ b/apps/ui/src/lib/proxies/redirects.test.ts
@@ -1,0 +1,99 @@
+import { NextRequest } from "next/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type * as RedirectsModule from "@/lib/redirects"
+
+const { findRedirectForPathMock } = vi.hoisted(() => ({
+  findRedirectForPathMock: vi.fn(),
+}))
+
+vi.mock("@/lib/navigation", () => ({
+  routing: {
+    defaultLocale: "en",
+  },
+}))
+
+vi.mock("server-only", () => ({}))
+
+// Keep the suite hermetic: importing the real `@/lib/redirects` below would
+// otherwise pull in the Strapi client and trigger env validation at import.
+vi.mock("@/lib/strapi-api/content/server", () => ({
+  fetchRedirects: vi.fn().mockResolvedValue([]),
+}))
+
+vi.mock("@/lib/redirects", async () => {
+  const actual =
+    await vi.importActual<typeof RedirectsModule>("@/lib/redirects")
+
+  return {
+    ...actual,
+    findRedirectForPath: findRedirectForPathMock,
+  }
+})
+
+import { redirectsProxy } from "./redirects"
+
+describe("redirectsProxy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findRedirectForPathMock.mockResolvedValue(null)
+  })
+
+  it("redirects matching GET requests with a temporary status", async () => {
+    findRedirectForPathMock.mockResolvedValue({
+      destination: "/en/new-page",
+    })
+
+    const response = await redirectsProxy(
+      new NextRequest("https://www.test/en/old-page?utm=test")
+    )
+
+    expect(response?.status).toBe(307)
+    expect(response?.headers.get("location")).toBe(
+      "https://www.test/new-page?utm=test"
+    )
+    expect(findRedirectForPathMock).toHaveBeenCalledWith("/en/old-page", "en")
+  })
+
+  it("continues when no redirect is found", async () => {
+    const response = await redirectsProxy(
+      new NextRequest("https://www.test/en/old-page")
+    )
+
+    expect(response).toBeNull()
+  })
+
+  it("ignores external redirect destinations", async () => {
+    findRedirectForPathMock.mockResolvedValue({
+      destination: "https://evil.com/new-page",
+    })
+
+    const response = await redirectsProxy(
+      new NextRequest("https://www.test/en/old-page")
+    )
+
+    expect(response).toBeNull()
+  })
+
+  it("ignores non-GET and non-HEAD requests", async () => {
+    const response = await redirectsProxy(
+      new NextRequest("https://www.test/en/old-page", { method: "POST" })
+    )
+
+    expect(response).toBeNull()
+    expect(findRedirectForPathMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores Next.js prefetch requests", async () => {
+    const response = await redirectsProxy(
+      new NextRequest("https://www.test/en/old-page", {
+        headers: {
+          "next-router-prefetch": "1",
+        },
+      })
+    )
+
+    expect(response).toBeNull()
+    expect(findRedirectForPathMock).not.toHaveBeenCalled()
+  })
+})

--- a/apps/ui/src/lib/proxies/redirects.ts
+++ b/apps/ui/src/lib/proxies/redirects.ts
@@ -1,0 +1,70 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { routing } from "@/lib/navigation"
+import {
+  buildRedirectDestinationUrl,
+  findRedirectForPath,
+} from "@/lib/redirects"
+
+export async function redirectsProxy(
+  req: NextRequest
+): Promise<NextResponse | null> {
+  if (!["GET", "HEAD"].includes(req.method)) {
+    // Redirects are only meaningful for navigational/idempotent requests.
+    return null
+  }
+
+  if (isPrefetchRequest(req)) {
+    // Next.js production prefetches visible links as RSC requests. Running
+    // redirect lookup for those speculative requests creates unnecessary
+    // Strapi traffic; the real navigation is checked separately.
+    return null
+  }
+
+  let redirect
+  try {
+    redirect = await findRedirectForPath(
+      req.nextUrl.pathname,
+      routing.defaultLocale
+    )
+  } catch (error) {
+    console.error("[redirectsProxy] Redirect lookup failed:", error)
+
+    // Proxy should fail open. A redirect lookup outage must not block normal
+    // page rendering.
+    return null
+  }
+
+  if (!redirect?.destination) return null
+
+  const destinationUrl = buildRedirectDestinationUrl(
+    req.nextUrl,
+    redirect.destination,
+    routing.defaultLocale
+  )
+
+  if (!destinationUrl) {
+    return null
+  }
+
+  if (destinationUrl.href === req.nextUrl.href) {
+    return null
+  }
+
+  // Always use 307 for CMS-managed redirects. A 308/301 is attractive for SEO
+  // once a move is truly final, but it is also sticky: browsers, crawlers, and
+  // intermediate caches can keep using it after editors fix or remove the
+  // redirect. A CDN can be purged, but user-agent caches cannot. These
+  // redirects are operational CMS content, so the safer default is a temporary
+  // method-preserving redirect that can be changed without leaving clients
+  // pinned to the old destination.
+  return NextResponse.redirect(destinationUrl, 307)
+}
+
+function isPrefetchRequest(req: NextRequest) {
+  return (
+    req.headers.has("next-router-prefetch") ||
+    req.headers.get("purpose") === "prefetch" ||
+    req.headers.get("sec-purpose") === "prefetch"
+  )
+}

--- a/apps/ui/src/lib/redirects.test.ts
+++ b/apps/ui/src/lib/redirects.test.ts
@@ -50,6 +50,19 @@ describe("redirect helpers", () => {
     expect(destination?.href).toBe("https://www.test/en/new-page?from=strapi")
   })
 
+  it("returns null for malformed destination URLs instead of throwing", () => {
+    // Note: most garbage strings ("not a url", "ht!tp://x") resolve as
+    // relative paths against the origin; only these shapes actually throw.
+    for (const malformed of ["https://", "http://exa mple.com/page", "//"]) {
+      const destination = buildRedirectDestinationUrl(
+        new URL("https://www.test/old-page"),
+        malformed
+      )
+
+      expect(destination).toBeNull()
+    }
+  })
+
   it("rejects external destinations", () => {
     const destination = buildRedirectDestinationUrl(
       new URL("https://www.test/en/old-page?utm=test"),
@@ -188,6 +201,40 @@ describe("redirect helpers", () => {
       }
     )
     expect(fetchManyMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps serving the last known redirects when a refresh fails", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    fetchManyMock
+      .mockResolvedValueOnce([
+        {
+          source: "/en/old-page",
+          destination: "/en/new-page",
+        },
+      ])
+      .mockRejectedValue(new Error("Strapi unavailable"))
+
+    await findRedirectForPath("/old-page", "en")
+
+    vi.setSystemTime(5 * 60 * 1000 + 1)
+
+    // Stale hit triggers a background refresh that fails; let it settle, then
+    // verify the failure did not replace the cached list with an empty one.
+    await expect(findRedirectForPath("/old-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/new-page",
+      }
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await expect(findRedirectForPath("/old-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/new-page",
+      }
+    )
   })
 
   it("continues with no redirect when an expired-cache miss refresh fails", async () => {

--- a/apps/ui/src/lib/redirects.test.ts
+++ b/apps/ui/src/lib/redirects.test.ts
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { fetchManyMock } = vi.hoisted(() => ({
+  fetchManyMock: vi.fn(),
+}))
+
+vi.mock("@/lib/strapi-api/content/server", () => ({
+  fetchRedirects: fetchManyMock,
+}))
+
+import {
+  buildRedirectDestinationUrl,
+  clearRedirectCache,
+  findRedirectForPath,
+} from "./redirects"
+
+describe("redirect helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+    clearRedirectCache()
+    fetchManyMock.mockResolvedValue([])
+  })
+
+  it("preserves the current query string when destination has none", () => {
+    const destination = buildRedirectDestinationUrl(
+      new URL("https://www.test/en/old-page?utm=test"),
+      "/en/new-page"
+    )
+
+    expect(destination?.href).toBe("https://www.test/en/new-page?utm=test")
+  })
+
+  it("removes the default locale prefix from internal destinations", () => {
+    const destination = buildRedirectDestinationUrl(
+      new URL("https://www.test/contact-us"),
+      "/en/contact-usxxxxxx",
+      "en"
+    )
+
+    expect(destination?.href).toBe("https://www.test/contact-usxxxxxx")
+  })
+
+  it("uses the destination query string when one is configured", () => {
+    const destination = buildRedirectDestinationUrl(
+      new URL("https://www.test/en/old-page?utm=test"),
+      "/en/new-page?from=strapi"
+    )
+
+    expect(destination?.href).toBe("https://www.test/en/new-page?from=strapi")
+  })
+
+  it("rejects external destinations", () => {
+    const destination = buildRedirectDestinationUrl(
+      new URL("https://www.test/en/old-page?utm=test"),
+      "https://evil.com/new-page"
+    )
+
+    expect(destination).toBeNull()
+  })
+
+  it("finds redirects from the cached redirect list", async () => {
+    fetchManyMock.mockResolvedValue([
+      {
+        source: "/en/old-page",
+        destination: "/en/new-page",
+      },
+    ])
+
+    const redirect = await findRedirectForPath("/old-page", "en")
+
+    expect(redirect).toMatchObject({
+      source: "/en/old-page",
+      destination: "/en/new-page",
+    })
+    expect(fetchManyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("matches sources stored with editor slips (whitespace, missing or trailing slash)", async () => {
+    fetchManyMock.mockResolvedValue([
+      { source: "en/old-page", destination: "/en/new-page" },
+      { source: " /en/other-page/ ", destination: "/en/other-destination" },
+    ])
+
+    await expect(findRedirectForPath("/old-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/new-page",
+      }
+    )
+    await expect(
+      findRedirectForPath("/other-page", "en")
+    ).resolves.toMatchObject({
+      destination: "/en/other-destination",
+    })
+  })
+
+  it("reuses the cached redirect list", async () => {
+    fetchManyMock.mockResolvedValue([
+      {
+        source: "/en/old-page",
+        destination: "/en/new-page",
+      },
+    ])
+
+    await findRedirectForPath("/old-page", "en")
+    await findRedirectForPath("/missing-page", "en")
+
+    expect(fetchManyMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("serves stale redirects while refreshing expired cache", async () => {
+    let resolveRefresh: (
+      redirects: { source: string; destination: string }[]
+    ) => void
+
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    fetchManyMock
+      .mockResolvedValueOnce([
+        {
+          source: "/en/old-page",
+          destination: "/en/old-destination",
+        },
+      ])
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveRefresh = resolve
+        })
+      )
+
+    await expect(findRedirectForPath("/old-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/old-destination",
+      }
+    )
+
+    vi.setSystemTime(5 * 60 * 1000 + 1)
+
+    await expect(findRedirectForPath("/old-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/old-destination",
+      }
+    )
+    expect(fetchManyMock).toHaveBeenCalledTimes(2)
+
+    resolveRefresh!([
+      {
+        source: "/en/new-page",
+        destination: "/en/new-destination",
+      },
+    ])
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await expect(findRedirectForPath("/new-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/new-destination",
+      }
+    )
+  })
+
+  it("waits for a refresh before returning an expired-cache miss", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    fetchManyMock
+      .mockResolvedValueOnce([
+        {
+          source: "/en/old-page",
+          destination: "/en/old-destination",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          source: "/en/new-page",
+          destination: "/en/new-destination",
+        },
+      ])
+
+    await findRedirectForPath("/old-page", "en")
+
+    vi.setSystemTime(5 * 60 * 1000 + 1)
+
+    await expect(findRedirectForPath("/new-page", "en")).resolves.toMatchObject(
+      {
+        destination: "/en/new-destination",
+      }
+    )
+    expect(fetchManyMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("continues with no redirect when an expired-cache miss refresh fails", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    fetchManyMock
+      .mockResolvedValueOnce([
+        {
+          source: "/en/old-page",
+          destination: "/en/old-destination",
+        },
+      ])
+      .mockRejectedValueOnce(new Error("Strapi unavailable"))
+
+    await findRedirectForPath("/old-page", "en")
+
+    vi.setSystemTime(5 * 60 * 1000 + 1)
+
+    await expect(findRedirectForPath("/new-page", "en")).resolves.toBeNull()
+    expect(fetchManyMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/ui/src/lib/redirects.ts
+++ b/apps/ui/src/lib/redirects.ts
@@ -101,7 +101,17 @@ export function buildRedirectDestinationUrl(
   destination: string,
   defaultLocale?: string
 ) {
-  const destinationUrl = new URL(destination, currentUrl.origin)
+  // Editors type `destination` by hand and some malformed values (e.g.
+  // "https://" or a host containing a space) make the URL constructor throw.
+  // One bad record must not take down the proxy for the matching path.
+  let destinationUrl: URL
+  try {
+    destinationUrl = new URL(destination, currentUrl.origin)
+  } catch {
+    console.error("[redirects] Invalid redirect destination:", destination)
+
+    return null
+  }
 
   if (destinationUrl.origin !== currentUrl.origin) {
     return null

--- a/apps/ui/src/lib/redirects.ts
+++ b/apps/ui/src/lib/redirects.ts
@@ -1,0 +1,179 @@
+import { normalizePageFullPath } from "@repo/shared-data"
+
+import { fetchRedirects } from "@/lib/strapi-api/content/server"
+
+type RedirectRecord = Awaited<ReturnType<typeof fetchRedirects>>[number]
+
+type RedirectCacheEntry = {
+  expiresAt: number
+  redirects: RedirectRecord[]
+}
+
+const REDIRECTS_CACHE_TTL_MS = 2 * 60 * 1000 // 2 minutes
+let redirectCache: RedirectCacheEntry | undefined
+
+// One in-flight fetch is shared by all concurrent requests. Without this guard,
+// a traffic burst after cache expiry could fan out into many identical Strapi
+// reads from the proxy path.
+let redirectFetchPromise: Promise<RedirectRecord[]> | undefined
+
+// Returns the best redirect record for the requested path. Default-locale URLs
+// can be visited with or without the locale prefix, so matching is done against
+// both normalized candidates while preserving preference order.
+export async function findRedirectForPath(
+  path: string,
+  defaultLocale: string
+): Promise<RedirectRecord | null> {
+  const cached = redirectCache
+  const sources = getRedirectSourceCandidates(path, defaultLocale)
+  const redirects = await getCachedRedirects()
+  const redirect = findRedirectInList(redirects, sources)
+
+  if (redirect || !cached || cached.expiresAt > Date.now()) {
+    return redirect
+  }
+
+  // An expired-cache hit can safely use the stale redirect while refreshing in
+  // the background. An expired-cache miss is different: a newly created redirect
+  // could be missing from this UI instance while a CDN in front of the app has
+  // already purged the old response. Refresh synchronously before allowing the
+  // request to fall through to normal page rendering, otherwise the CDN could
+  // cache a stale 404/200 for the source URL.
+  return findRedirectInList(await refreshRedirects(), sources)
+}
+
+export function clearRedirectCache() {
+  redirectCache = undefined
+  redirectFetchPromise = undefined
+}
+
+async function getCachedRedirects() {
+  const cached = redirectCache
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.redirects
+  }
+
+  // Cold cache must wait for Strapi because there is no safe fallback list yet.
+  // Expired cache serves stale data immediately and refreshes in the background;
+  // redirects are low-churn content, and avoiding request latency spikes in the
+  // proxy is more valuable than blocking on every TTL boundary.
+  void refreshRedirects()
+
+  if (cached) {
+    return cached.redirects
+  }
+
+  return redirectFetchPromise ?? []
+}
+
+// Stores the whole published redirect list as one small object. The site is
+// expected to have only a handful of redirects, so a single cached list keeps
+// lookup simple and avoids per-path cache fragmentation.
+function cacheRedirects(redirects: RedirectRecord[]) {
+  redirectCache = {
+    expiresAt: Date.now() + REDIRECTS_CACHE_TTL_MS,
+    redirects,
+  }
+
+  return redirects
+}
+
+// Refresh failures should not break navigation. If Strapi is temporarily down,
+// keep serving the last known redirect list until a later refresh succeeds.
+function refreshRedirects() {
+  redirectFetchPromise ??= fetchRedirects()
+    .then(cacheRedirects)
+    .catch((error: unknown) => {
+      console.error("[redirects] Failed to refresh redirect cache:", error)
+
+      return redirectCache?.redirects ?? []
+    })
+    .finally(() => {
+      redirectFetchPromise = undefined
+    })
+
+  return redirectFetchPromise
+}
+
+export function buildRedirectDestinationUrl(
+  currentUrl: URL,
+  destination: string,
+  defaultLocale?: string
+) {
+  const destinationUrl = new URL(destination, currentUrl.origin)
+
+  if (destinationUrl.origin !== currentUrl.origin) {
+    return null
+  }
+
+  if (defaultLocale) {
+    // Strapi stores redirects with locale prefixes, but the public app uses
+    // `localePrefix: "as-needed"`. Strip the default locale to avoid an
+    // extra next-intl canonicalization redirect.
+    destinationUrl.pathname = stripDefaultLocalePrefix(
+      destinationUrl.pathname,
+      defaultLocale
+    )
+  }
+
+  if (!destinationUrl.search) {
+    // Preserve campaign/query params from the original request unless editors
+    // intentionally configured a query string on the redirect destination.
+    destinationUrl.search = currentUrl.search
+  }
+
+  return destinationUrl
+}
+
+function getRedirectSourceCandidates(path: string, defaultLocale: string) {
+  // Strapi redirect records are stored with locale prefixes, while public
+  // default-locale URLs may be unprefixed. Check both forms for default locale.
+  return [
+    ...new Set([
+      normalizePageFullPath([path]),
+      normalizePageFullPath([path], defaultLocale),
+    ]),
+  ]
+}
+
+function findRedirectInList(redirects: RedirectRecord[], sources: string[]) {
+  return (
+    sources
+      .map((source) =>
+        redirects.find(
+          (redirect) =>
+            redirect.source &&
+            normalizeRedirectSource(redirect.source) === source
+        )
+      )
+      .find(Boolean) ?? null
+  )
+}
+
+// Editors type `source` by hand, so tolerate the common slips — surrounding
+// whitespace, a missing leading slash, a trailing slash — instead of letting
+// the record silently never match. The request-side candidates are already
+// canonical (Next.js strips trailing slashes before the proxy runs).
+function normalizeRedirectSource(source: string) {
+  const normalized = normalizePageFullPath([source.trim()])
+
+  return normalized.length > 1 && normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized
+}
+
+function stripDefaultLocalePrefix(pathname: string, defaultLocale: string) {
+  const localePrefix = `/${defaultLocale}`
+
+  if (pathname === localePrefix) {
+    // `/en` should canonicalize to the root path for the default locale.
+    return "/"
+  }
+
+  if (pathname.startsWith(`${localePrefix}/`)) {
+    return pathname.slice(localePrefix.length)
+  }
+
+  return pathname
+}

--- a/apps/ui/src/lib/strapi-api/base.ts
+++ b/apps/ui/src/lib/strapi-api/base.ts
@@ -19,6 +19,7 @@ export const API_ENDPOINTS: Partial<Record<UID.ContentType, string>> = {
   "api::footer.footer": "/footer",
   "api::navbar.navbar": "/navbar",
   "api::subscriber.subscriber": "/subscribers",
+  "api::redirect.redirect": "/redirects",
 } as const
 
 export default abstract class BaseStrapiClient {

--- a/apps/ui/src/lib/strapi-api/content/server.ts
+++ b/apps/ui/src/lib/strapi-api/content/server.ts
@@ -208,3 +208,37 @@ export async function fetchFooter(locale: Locale) {
     })
   }
 }
+
+// ------ Redirect fetching functions
+
+export async function fetchRedirects() {
+  try {
+    // fetchAll paginates through every page — a redirect list capped at one
+    // page would silently drop redirects beyond the page size (easy to hit
+    // after a site migration).
+    const response = await PublicStrapiClient.fetchAll(
+      "api::redirect.redirect",
+      {
+        status: "published",
+      },
+      {
+        // Redirects are cached in-process by `src/lib/redirects.ts`. Avoid
+        // stacking Next's Data Cache underneath it, because proxy refreshes
+        // should decide freshness from the local stale-while-refresh cache.
+        cache: "no-store",
+      }
+    )
+
+    return response.data
+  } catch (e: unknown) {
+    logNonBlockingError({
+      message: "Error fetching redirects",
+      error: {
+        error: e instanceof Error ? e.message : String(e),
+        stack: e instanceof Error ? e.stack : undefined,
+      },
+    })
+
+    return []
+  }
+}

--- a/apps/ui/src/lib/strapi-api/content/server.ts
+++ b/apps/ui/src/lib/strapi-api/content/server.ts
@@ -239,6 +239,9 @@ export async function fetchRedirects() {
       },
     })
 
-    return []
+    // Rethrow instead of returning [] — the redirect cache must distinguish
+    // "no redirects exist" from "Strapi unreachable". An empty list here would
+    // be cached and wipe the last known good redirects for a full TTL.
+    throw e instanceof Error ? e : new Error(String(e))
   }
 }

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -6,6 +6,7 @@ import { authGuard } from "@/lib/proxies/authGuard"
 import { basicAuth } from "@/lib/proxies/basicAuth"
 import { dynamicRewrite } from "@/lib/proxies/dynamicRewrite"
 import { httpsRedirect } from "@/lib/proxies/httpsRedirect"
+import { redirectsProxy } from "@/lib/proxies/redirects"
 import { withSecurityHeaders } from "@/lib/proxies/securityHeaders"
 
 // https://next-intl-docs.vercel.app/docs/getting-started/app-router
@@ -18,6 +19,7 @@ const proxies: ((
 ) => NextResponse | null | Promise<NextResponse | null>)[] = [
   basicAuth,
   httpsRedirect,
+  redirectsProxy,
   (req) => authGuard(req, intlProxy),
   (req) => dynamicRewrite(req, intlProxy),
 ]


### PR DESCRIPTION
closes #334 

## Summary

The starter stored redirects in Strapi (the **Redirect** collection, `source` → `destination`) but the Next.js app never acted on them. This adds UI-side redirect handling, generalized for the starter.

- **Redirects proxy** (`apps/ui/src/lib/proxies/redirects.ts`) — matches each incoming request against the published redirect list and issues the redirect before the page renders. `GET`/`HEAD` only, skips Next.js prefetches, fails open, always issues a `307`.
- **In-memory cache** (`apps/ui/src/lib/redirects.ts`) — 2-minute TTL so not every request hits Strapi. Shared in-flight fetch, stale-while-refresh, with a synchronous refresh on an expired-cache *miss* (closes the race where a CDN already evicted the old response but this instance hasn't seen the new redirect). Same-origin destinations only; visitor query string preserved; default-locale URLs matched with/without prefix; editor `source` typos (whitespace, missing/trailing slash) matched forgivingly.
- **Wiring** — `redirectsProxy` runs in `apps/ui/src/proxy.ts` after the HTTPS redirect, before auth guard / dynamic rewrite.
- **Data layer** — `fetchRedirects` uses `fetchAll` (paginates; no 100-entry cap) and registers the `/redirects` API endpoint.
- **Schema** — dropped the unused `permanent` attribute (the proxy is `307`-only by design); cleaned generated types and config-sync snapshots to match.

## Docs

- New **CMS Redirects** page under Strapi (locale-aware behavior, manual vs. auto-created, 307-only, cache revalidation).
- Cross-linked **Pages Hierarchy** ↔ CMS Redirects, updated **Proxies** and **Features** docs.

## Notes

- **307 only:** CMS-managed redirects are temporary by design — a `308`/`301` sticks in browser/crawler caches and can't be recalled when an editor fixes an entry.
- **Activation latency:** a newly published/edited redirect goes live within the cache TTL (~2 min per instance). Publish-time revalidation can't reach the proxy bundle's in-memory cache, so the TTL is the activation bound (`REDIRECTS_CACHE_TTL_MS`).
- The docs also describe an **alternative** CDN/edge approach for larger sites with a programmable CDN.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - CMS Redirects: Editors can now manage URL redirects directly in Strapi. Redirects are applied as temporary (307) redirects before page render with locale awareness and automatic creation on page moves.
  - UI proxy now handles Strapi-defined redirects in the request chain.

* **Documentation**
  - Added comprehensive CMS Redirects documentation.
  - Updated proxy and page hierarchy documentation for redirect handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->