### PR TITLE
feat(ui): gate sitemap access in non-production deployments

### DIFF
--- a/apps/docs/docs/ui/seo.md
+++ b/apps/docs/docs/ui/seo.md
@@ -35,6 +35,15 @@ To include more pageable collections in the sitemap, add their UIDs to `pageEnti
 
 The sitemap returns an empty list when the app is not production or development, or when `APP_PUBLIC_URL` is not configured.
 
+### Access
+
+Access to `/sitemap.xml` is gated by the `authSitemap` proxy in `lib/proxies/authSitemap.ts`, wired into the middleware chain in `proxy.ts`:
+
+- In **production** and **local development** the sitemap is unrestricted (so search engines can crawl it, and it stays easy to inspect locally).
+- In **non-production deployments** (e.g. staging/preview) the request must include the `?allow-sitemap=yes` query parameter; otherwise it returns `404`. This keeps those sitemaps out of search indexes while still allowing on-demand inspection.
+
+The proxy requires no environment variables. Note that `/sitemap.xml` is listed explicitly in the middleware `matcher` so the proxy runs for it.
+
 ## Robots
 
 `app/robots.ts` generates `robots.txt`.

--- a/apps/ui/src/lib/proxies/authSitemap.ts
+++ b/apps/ui/src/lib/proxies/authSitemap.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server"
+
+import { isDevelopment, isProduction } from "@/lib/general-helpers"
+
+const SITEMAP_PROTECTED_PATHS = new Set(["/sitemap.xml"])
+
+const ALLOW_SITEMAP_PARAM = "allow-sitemap"
+const ALLOW_SITEMAP_VALUE = "yes"
+
+const isSitemapProtectedPath = (pathname: string): boolean =>
+  SITEMAP_PROTECTED_PATHS.has(pathname)
+
+/**
+ * Gates the generated sitemap behind an `?allow-sitemap=yes` query parameter in
+ * non-production deployments. Returns a response for protected paths so they
+ * bypass downstream proxies.
+ */
+export const authSitemap = (req: NextRequest): NextResponse | null => {
+  if (!isSitemapProtectedPath(req.nextUrl.pathname)) {
+    return null
+  }
+
+  if (isProduction() || isDevelopment()) {
+    return NextResponse.next()
+  }
+
+  if (
+    req.nextUrl.searchParams.get(ALLOW_SITEMAP_PARAM) === ALLOW_SITEMAP_VALUE
+  ) {
+    return NextResponse.next()
+  }
+
+  const res = new NextResponse("Not found", { status: 404 })
+  // Prevent CDNs/intermediaries from caching the denial, which would otherwise
+  // make later `?allow-sitemap=yes` requests appear broken.
+  res.headers.set("Cache-Control", "private, no-store")
+
+  return res
+}

--- a/apps/ui/src/proxy.ts
+++ b/apps/ui/src/proxy.ts
@@ -3,6 +3,7 @@ import createMiddleware from "next-intl/middleware"
 
 import { routing } from "@/lib/navigation"
 import { authGuard } from "@/lib/proxies/authGuard"
+import { authSitemap } from "@/lib/proxies/authSitemap"
 import { basicAuth } from "@/lib/proxies/basicAuth"
 import { dynamicRewrite } from "@/lib/proxies/dynamicRewrite"
 import { httpsRedirect } from "@/lib/proxies/httpsRedirect"
@@ -19,6 +20,7 @@ const proxies: ((
 ) => NextResponse | null | Promise<NextResponse | null>)[] = [
   basicAuth,
   httpsRedirect,
+  authSitemap,
   redirectsProxy,
   (req) => authGuard(req, intlProxy),
   (req) => dynamicRewrite(req, intlProxy),
@@ -45,6 +47,8 @@ export const config = {
   matcher: [
     // Enable a redirect to a matching locale at the root
     "/",
+    // Gate the generated sitemap in non-production deployed environments
+    "/sitemap.xml",
     // Set a cookie to remember the previous locale for
     // all requests that have a locale prefix
     `/(cs|en)/:path*`,


### PR DESCRIPTION
Adds an `authSitemap` middleware proxy that gates `/sitemap.xml` behind an `?allow-sitemap=yes` query parameter in non-production deployments, while keeping it publicly crawlable in production. This keeps staging/preview sitemaps out of search indexes.

- New `apps/ui/src/lib/proxies/authSitemap.ts` (no env vars required)
- Wired into the proxy chain and added `/sitemap.xml` to the middleware `matcher` (previously excluded, so middleware never ran for it)
- Documented under SEO → Sitemap → Access in the docs

Ported from the Yale origin and adapted to the starter: the starter's generic `basicAuth` (whole-app, env-gated) is left untouched — this is a complementary sitemap-specific gate, not a replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-aware sitemap access control: publicly accessible in production, requires authentication parameter in non-production environments.

* **Documentation**
  * Updated documentation to clarify sitemap configuration, accessibility rules, and access control mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->