### PR TITLE
feat(strapi): rate-limit users-permissions auth endpoints

### DIFF
--- a/apps/strapi/config/plugins.ts
+++ b/apps/strapi/config/plugins.ts
@@ -14,6 +14,14 @@ export default ({ env }) => {
         jwt: {
           expiresIn: "30d", // this value is synced with Better Auth session maxAge
         },
+        // Rate limiting for auth/registration endpoints (login, register,
+        // forgot/reset password) to mitigate brute-force and abuse.
+        // https://docs.strapi.io/cms/features/users-permissions#rate-limiting-configuration
+        ratelimit: {
+          enabled: true,
+          interval: 60000, // 1 minute window
+          max: 5, // max 5 requests per window, per user/path/IP
+        },
       },
     },
 


### PR DESCRIPTION
## Summary

Enable rate limiting on the `users-permissions` plugin's auth/registration endpoints (login, register, forgot/reset password) to mitigate brute-force and credential-stuffing attacks.

Configured in [apps/strapi/config/plugins.ts](apps/strapi/config/plugins.ts) per the [Strapi docs](https://docs.strapi.io/cms/features/users-permissions#rate-limiting-configuration):

- `enabled: true`
- `interval: 60000` — 1 minute window
- `max: 5` — max 5 requests per window (keyed per user/path/IP)

These are reasonable defaults for auth routes — strict enough to blunt brute-force attempts while leaving room for legitimate retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)