### PR TITLE
Fix: qa pipeline chromium only for axe and seo

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -130,7 +130,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright Browsers
-        run: pnpm -F @repo/tests-playwright exec playwright install --with-deps
+        run: pnpm -F @repo/tests-playwright exec playwright install --with-deps chromium
 
       - name: Run Axe tests
         env:
@@ -174,7 +174,7 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install Playwright Browsers
-        run: pnpm -F @repo/tests-playwright exec playwright install --with-deps
+        run: pnpm -F @repo/tests-playwright exec playwright install --with-deps chromium
 
       - name: Run Playwright SEO tests
         env:


### PR DESCRIPTION
### Description

# What
The axe and seo QA jobs now install only Chromium instead of all three browsers.

# Why
Both run exclusively on Chromium (--project=axe / --project=seo), so downloading Firefox and WebKit was wasted overhead. Scoping to Chromium makes these jobs faster and leaner — less setup time, bandwidth, and cache.

# Notes
e2e left unchanged — it genuinely tests all three browsers.
Kept --with-deps for Chromium's system libraries.